### PR TITLE
feat: normalize affected module root labels

### DIFF
--- a/docs/g2-3-summary-eval-set.json
+++ b/docs/g2-3-summary-eval-set.json
@@ -39,7 +39,7 @@
         },
         "affected_modules": [
           {
-            "module": "main.rs",
+            "module": "(root)",
             "symbol_count": 2,
             "file_count": 1
           }
@@ -107,7 +107,7 @@
             "file_count": 2
           },
           {
-            "module": "main.rs",
+            "module": "(root)",
             "symbol_count": 2,
             "file_count": 1
           },
@@ -152,7 +152,7 @@
         },
         "affected_modules": [
           {
-            "module": "main.rs",
+            "module": "(root)",
             "symbol_count": 2,
             "file_count": 1
           }

--- a/docs/g2-3-summary-eval-set.md
+++ b/docs/g2-3-summary-eval-set.md
@@ -10,10 +10,10 @@
 
 | case_id | lang | shape | anchor | observed risk | by_depth view | affected_modules (top) | focus |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| rust-callers-chain | rust | chain | medium | medium (d=1, t=1, f=1, s=2) | d1:1s/1f, d2:1s/1f | main.rs(2/1) | minimal direct/transitive baseline |
+| rust-callers-chain | rust | chain | medium | medium (d=1, t=1, f=1, s=2) | d1:1s/1f, d2:1s/1f | (root)(2/1) | minimal direct/transitive baseline |
 | rust-confidence-filter-empty | rust | filtered-empty | low | low (d=0, t=0, f=0, s=0) | [] | [] | confidence filter shrink-to-empty floor |
-| rust-module-fanout | rust | fan-out | high | high (d=4, t=1, f=4, s=5) | d1:4s/4f, d2:1s/1f | alpha(2/2), main.rs(2/1), beta(1/1) | affected_modules ordering and grouping baseline |
-| rust-confidence-hard | rust | local-dispatch | medium | medium (d=1, t=1, f=1, s=2) | d1:1s/1f, d2:1s/1f | main.rs(2/1) | localized hard fixture with small caller spread |
+| rust-module-fanout | rust | fan-out | high | high (d=4, t=1, f=4, s=5) | d1:4s/4f, d2:1s/1f | alpha(2/2), (root)(2/1), beta(1/1) | affected_modules ordering and grouping baseline |
+| rust-confidence-hard | rust | local-dispatch | medium | medium (d=1, t=1, f=1, s=2) | d1:1s/1f, d2:1s/1f | (root)(2/1) | localized hard fixture with small caller spread |
 | python-monkeypatch-v4 | python | dynamic-fan-out | high | high (d=3, t=3, f=1, s=6) | d1:3s/1f, d2:3s/1f | demo(6/1) | dynamic caller spread and high-risk anchor |
 | ruby-method-missing-v4 | ruby | dynamic | high | medium (d=1, t=0, f=1, s=1) | d1:1s/1f | demo(1/1) | dynamic Ruby boundary case for underestimation checks |
 | go-heavy-diff | go | wide-fan-out | high | high (d=1, t=30, f=1, s=31) | 31 buckets; direct=1; transitive=30; max_depth=31 | bench-fixtures/go-heavy(31/1) | high-risk scale anchor from repo diff fixture |

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -158,12 +158,31 @@ pub(crate) fn build_risk_summary(
     }
 }
 
+fn is_entry_like_module_file(name: &str) -> bool {
+    matches!(
+        name,
+        "main.rs" | "lib.rs" | "mod.rs" | "index.js" | "index.ts" | "index.tsx" | "__init__.py"
+    )
+}
+
 fn affected_module_for_file(file: &str) -> String {
     let normalized = file.strip_prefix("./").unwrap_or(file).replace('\\', "/");
     let path = std::path::Path::new(&normalized);
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty() && *parent != std::path::Path::new("."));
 
-    path.parent()
-        .filter(|parent| !parent.as_os_str().is_empty() && *parent != std::path::Path::new("."))
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(is_entry_like_module_file)
+    {
+        return parent
+            .map(|parent| parent.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| "(root)".to_string());
+    }
+
+    parent
         .map(|parent| parent.to_string_lossy().replace('\\', "/"))
         .unwrap_or(normalized)
 }
@@ -193,6 +212,7 @@ pub(crate) fn build_affected_modules_summary(
     summary.sort_by(|a, b| {
         b.symbol_count
             .cmp(&a.symbol_count)
+            .then_with(|| (a.module == "(root)").cmp(&(b.module == "(root)")))
             .then_with(|| a.module.cmp(&b.module))
     });
     summary
@@ -1026,6 +1046,59 @@ fn foo() { bar(); }
             "pkg::service::main"
         );
         assert_eq!(module_path_for_file("demo/Ops.java"), "demo::Ops");
+    }
+
+    #[test]
+    fn affected_module_for_file_normalizes_entry_like_labels() {
+        assert_eq!(affected_module_for_file("main.rs"), "(root)");
+        assert_eq!(affected_module_for_file("src/main.rs"), "src");
+        assert_eq!(affected_module_for_file("src/lib.rs"), "src");
+        assert_eq!(affected_module_for_file("src/engine/mod.rs"), "src/engine");
+        assert_eq!(affected_module_for_file("web/index.ts"), "web");
+        assert_eq!(affected_module_for_file("pkg/__init__.py"), "pkg");
+        assert_eq!(affected_module_for_file("foo.rs"), "foo.rs");
+    }
+
+    #[test]
+    fn build_affected_modules_summary_keeps_root_after_named_dirs_on_tie() {
+        let make_symbol = |file: &str, name: &str, line: u32| Symbol {
+            id: crate::ir::SymbolId::new(
+                "rust",
+                file,
+                &crate::ir::SymbolKind::Function,
+                name,
+                line,
+            ),
+            name: name.to_string(),
+            kind: crate::ir::SymbolKind::Function,
+            file: file.to_string(),
+            range: crate::ir::TextRange {
+                start_line: line,
+                end_line: line,
+            },
+            language: "rust".to_string(),
+        };
+
+        let summary = build_affected_modules_summary(&[
+            make_symbol("main.rs", "main", 1),
+            make_symbol("main.rs", "root_one", 2),
+            make_symbol("alpha/first.rs", "alpha_one", 3),
+            make_symbol("alpha/second.rs", "alpha_two", 4),
+            make_symbol("beta/first.rs", "beta_one", 5),
+        ]);
+
+        let observed: Vec<(String, usize, usize)> = summary
+            .into_iter()
+            .map(|item| (item.module, item.symbol_count, item.file_count))
+            .collect();
+        assert_eq!(
+            observed,
+            vec![
+                ("alpha".to_string(), 2, 2),
+                ("(root)".to_string(), 2, 1),
+                ("beta".to_string(), 1, 1),
+            ]
+        );
     }
 
     #[test]

--- a/tests/cli_impact_affected_modules.rs
+++ b/tests/cli_impact_affected_modules.rs
@@ -180,7 +180,7 @@ fn cli_impact_json_includes_affected_modules_summary() {
         affected_modules_json(&output),
         vec![
             ("alpha".to_string(), 2, 2),
-            ("main.rs".to_string(), 2, 1),
+            ("(root)".to_string(), 2, 1),
             ("beta".to_string(), 1, 1),
         ]
     );
@@ -200,7 +200,7 @@ fn cli_impact_per_seed_nests_affected_modules_under_output_summary() {
         affected_modules_json(&grouped[0]["impacts"][0]["output"]),
         vec![
             ("alpha".to_string(), 2, 2),
-            ("main.rs".to_string(), 2, 1),
+            ("(root)".to_string(), 2, 1),
             ("beta".to_string(), 1, 1),
         ]
     );
@@ -217,7 +217,7 @@ fn cli_impact_yaml_includes_affected_modules_summary() {
         affected_modules_yaml(&output),
         vec![
             ("alpha".to_string(), 2, 2),
-            ("main.rs".to_string(), 2, 1),
+            ("(root)".to_string(), 2, 1),
             ("beta".to_string(), 1, 1),
         ]
     );


### PR DESCRIPTION
## Summary
- normalize entry-like files in `affected_modules` so root `main.rs`/`lib.rs`/`mod.rs`/`index.*`/`__init__.py` collapse to `(root)` or their parent directory
- keep path-based grouping lightweight, but avoid mixing root file names with directory buckets in summary output
- lock the new display through unit tests, normal CLI tests, per-seed tests, YAML tests, and refreshed G2-3 summary snapshots

## Testing
- cargo test affected_module -- --nocapture
- cargo test --test cli_impact_affected_modules -- --nocapture
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- python3 scripts/collect-summary-eval.py --skip-build --out-json docs/g2-3-summary-eval-set.json --out-md docs/g2-3-summary-eval-set.md