### PR TITLE
docs: clarify G2 impact summary guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ CLI Overview
     - `depth=1` is the direct hit set
     - `depth>=2` shows transitive spread
   - `summary.risk`
-    - lightweight first-pass severity estimate built from direct hits, transitive hits, impacted file count, and impacted symbol count
-    - meant for review/CI triage, not as a replacement for inspecting the raw graph
+    - lightweight first-pass triage priority built from direct hits, transitive hits, impacted file count, and impacted symbol count
+    - read it as review/CI priority, not as a production-severity prediction or a replacement for inspecting the raw graph
+    - rough reading guide:
+      - `low`: likely local; start near the changed code
+      - `medium`: not huge, but callers or nearby files are worth checking
+      - `high`: broad enough that you should assume caller-side spread and inspect the graph early
   - `summary.affected_modules`
     - lightweight path-based grouping of impacted symbols
     - useful for answering “which area of the repo should I inspect next?”
+    - entry-like files are normalized for readability: `src/main.rs` / `src/lib.rs` / `src/engine/mod.rs` collapse to their parent path, and root-level entry files collapse to `(root)`
+- There is still no `summary.affected_processes`; that remains intentionally deferred until entrypoint heuristics and fixtures are strong enough.
 - Typical JSON shape:
   ```json
   {
@@ -86,7 +92,7 @@ CLI Overview
       },
       "affected_modules": [
         { "module": "src/engine", "symbol_count": 4, "file_count": 2 },
-        { "module": "src/bin", "symbol_count": 2, "file_count": 1 }
+        { "module": "(root)", "symbol_count": 2, "file_count": 1 }
       ]
     },
     "confidence_filter": {
@@ -99,8 +105,8 @@ CLI Overview
   ```
 - Operational intent:
   - start with `by_depth` to separate direct vs transitive impact
-  - use `risk` to prioritize review/CI follow-up
-  - use `affected_modules` to decide which directories/modules to open next
+  - use `risk` to decide how aggressively to triage the diff (`low` = local-first, `medium` = nearby spread worth checking, `high` = broad-wave suspicion)
+  - use `affected_modules` to decide which directories/modules to open next; `(root)` means the repo-root entry area, not a literal module named `main.rs`
   - then inspect `impacted_symbols` / `edges` for the concrete graph details
 - `confidence_filter` remains a top-level sibling of `summary`, not a field inside it.
 - With `--per-seed`, the same summary appears under `impacts[].output.summary` for each changed/seed symbol.

--- a/README_ja.md
+++ b/README_ja.md
@@ -75,11 +75,17 @@ dimpact id --name foo -f json
     - `depth=1` は direct hit
     - `depth>=2` は transitive な波及
   - `summary.risk`
-    - direct hit 数、transitive hit 数、影響 file 数、影響 symbol 数から作る軽量な初期リスク評価
-    - レビュー/CI トリアージ向けの目安であり、生のグラフ確認の代替ではありません
+    - direct hit 数、transitive hit 数、影響 file 数、影響 symbol 数から作る軽量な一次トリアージ優先度
+    - 本番障害の severity 予測ではなく、レビュー/CI でどれくらい慎重に見るべきかの目安です
+    - ざっくりした読み方:
+      - `low`: まず局所 diff とみなして変更近傍から見る
+      - `medium`: 近い caller や周辺 file まで確認候補に入れる
+      - `high`: caller 側へ広く波及している前提で早めにグラフを確認する
   - `summary.affected_modules`
     - impacted symbol を path ベースで軽量にグルーピングしたもの
     - 「次にどのディレクトリ / モジュールを開くべきか」を決めるための補助です
+    - 読みやすさのため、`src/main.rs` / `src/lib.rs` / `src/engine/mod.rs` のような entry-like file は親ディレクトリへ畳み、repo root の entry file は `(root)` と表示されます
+- 現時点では `summary.affected_processes` はありません。entrypoint 判定の heuristic と fixture を固めるまで意図的に見送っています。
 - JSON のイメージ:
   ```json
   {
@@ -102,7 +108,7 @@ dimpact id --name foo -f json
       },
       "affected_modules": [
         { "module": "src/engine", "symbol_count": 4, "file_count": 2 },
-        { "module": "src/bin", "symbol_count": 2, "file_count": 1 }
+        { "module": "(root)", "symbol_count": 2, "file_count": 1 }
       ]
     },
     "confidence_filter": {
@@ -115,8 +121,8 @@ dimpact id --name foo -f json
   ```
 - 運用上の読み順:
   - まず `by_depth` で direct / transitive を分けて見る
-  - 次に `risk` でレビュー優先度や CI 上の注意度をざっくり判断する
-  - `affected_modules` で、次に見るべきディレクトリ / モジュールを絞る
+  - 次に `risk` でどれくらい強くトリアージすべきかを判断する（`low` = 局所優先、`medium` = 近傍 caller まで確認、`high` = 広い波及を疑う）
+  - `affected_modules` で、次に見るべきディレクトリ / モジュールを絞る。`(root)` は `main.rs` という file 名そのものではなく、repo root の entry 周辺を指します
   - 最後に `impacted_symbols` / `edges` で具体的な伝播経路を確認する
 - `confidence_filter` は `summary` の中ではなく、引き続きトップレベル sibling として出ます。
 - `--per-seed` 指定時は、各変更/シードシンボルごとの `impacts[].output.summary` 配下に同じ summary が入ります。


### PR DESCRIPTION
## Summary
- update README and README_ja with the G2 reading guidance for `summary.risk`
- document the new `(root)` / entry-like normalization in `summary.affected_modules`
- explicitly note that `affected_processes` is still deferred so readers do not expect it in current summary output

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test