### PR TITLE
fix(pdg): preserve merged edge metadata

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -4,11 +4,11 @@ use dimpact::EngineConfig;
 use dimpact::cache;
 use dimpact::compute_changed_symbols;
 use dimpact::compute_impact;
-use dimpact::dfg::{DataFlowGraph, PdgBuilder, RubyDfgBuilder, RustDfgBuilder};
+use dimpact::dfg::{DataFlowGraph, DependencyKind, PdgBuilder, RubyDfgBuilder, RustDfgBuilder};
 use dimpact::dfg_to_dot;
 use dimpact::engine::{AutoPolicy, EngineKind, make_engine_with_auto_policy};
 use dimpact::ir::SymbolId;
-use dimpact::ir::reference::{EdgeCertainty, RefKind, Reference, SymbolIndex};
+use dimpact::ir::reference::{EdgeCertainty, EdgeProvenance, RefKind, Reference, SymbolIndex};
 use dimpact::{ChangedOutput, LanguageMode};
 use dimpact::{DiffParseError, parse_unified_diff};
 use dimpact::{ImpactDirection, ImpactOptions, ImpactOutput};
@@ -921,6 +921,148 @@ struct PerSeedOutput {
 }
 
 #[allow(clippy::too_many_arguments)]
+fn strongest_certainty(a: EdgeCertainty, b: EdgeCertainty) -> EdgeCertainty {
+    if certainty_rank(a.clone()) >= certainty_rank(b.clone()) {
+        a
+    } else {
+        b
+    }
+}
+
+fn ref_kind_from_dependency(kind: &DependencyKind) -> RefKind {
+    match kind {
+        DependencyKind::Data => RefKind::Data,
+        DependencyKind::Control => RefKind::Control,
+    }
+}
+
+fn edge_location_from_nodes(
+    from: &str,
+    to: &str,
+    nodes_by_id: &std::collections::HashMap<String, (String, u32)>,
+    callsite_certainty_by_loc: &std::collections::HashMap<(String, u32), EdgeCertainty>,
+) -> (String, u32, Option<EdgeCertainty>) {
+    let from_loc = nodes_by_id.get(from).cloned();
+    let to_loc = nodes_by_id.get(to).cloned();
+
+    let mut derived_certainty = None;
+    let mut callsite_loc = None;
+    if let Some(loc) = from_loc.clone()
+        && let Some(certainty) = callsite_certainty_by_loc.get(&loc)
+    {
+        derived_certainty = Some(certainty.clone());
+        callsite_loc = Some(loc);
+    }
+    if let Some(loc) = to_loc.clone()
+        && let Some(certainty) = callsite_certainty_by_loc.get(&loc)
+    {
+        derived_certainty = Some(match derived_certainty {
+            Some(existing) => strongest_certainty(existing, certainty.clone()),
+            None => certainty.clone(),
+        });
+        if callsite_loc.is_none() {
+            callsite_loc = Some(loc);
+        }
+    }
+    if let Some((file, line)) = callsite_loc {
+        return (file, line, derived_certainty);
+    }
+    if let Some((file, line)) = to_loc {
+        return (file, line, derived_certainty);
+    }
+    if let Some((file, line)) = from_loc {
+        return (file, line, derived_certainty);
+    }
+    (String::new(), 0, derived_certainty)
+}
+
+fn merge_pdg_references(
+    combined: &DataFlowGraph,
+    pdg: &DataFlowGraph,
+    refs: &[Reference],
+) -> Vec<Reference> {
+    let mut merged = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut push_ref = |r: Reference| {
+        let key = (
+            r.from.0.clone(),
+            r.to.0.clone(),
+            r.kind.clone(),
+            r.file.clone(),
+            r.line,
+            r.certainty.clone(),
+            r.provenance.clone(),
+        );
+        if seen.insert(key) {
+            merged.push(r);
+        }
+    };
+
+    let nodes_by_id: std::collections::HashMap<String, (String, u32)> = combined
+        .nodes
+        .iter()
+        .map(|n| (n.id.clone(), (n.file.clone(), n.line)))
+        .collect();
+    let mut callsite_certainty_by_loc: std::collections::HashMap<(String, u32), EdgeCertainty> =
+        std::collections::HashMap::new();
+    for r in refs {
+        let key = (r.file.clone(), r.line);
+        callsite_certainty_by_loc
+            .entry(key)
+            .and_modify(|existing| {
+                *existing = strongest_certainty(existing.clone(), r.certainty.clone())
+            })
+            .or_insert_with(|| r.certainty.clone());
+        let mut base_ref = r.clone();
+        base_ref.provenance = EdgeProvenance::CallGraph;
+        push_ref(base_ref);
+    }
+
+    for e in &combined.edges {
+        let (file, line, _) =
+            edge_location_from_nodes(&e.from, &e.to, &nodes_by_id, &callsite_certainty_by_loc);
+        push_ref(Reference {
+            from: SymbolId(e.from.clone()),
+            to: SymbolId(e.to.clone()),
+            kind: ref_kind_from_dependency(&e.kind),
+            file,
+            line,
+            certainty: EdgeCertainty::Inferred,
+            provenance: EdgeProvenance::LocalDfg,
+        });
+    }
+
+    let mut base_edge_keys: std::collections::HashSet<(String, String, DependencyKind)> = combined
+        .edges
+        .iter()
+        .map(|e| (e.from.clone(), e.to.clone(), e.kind.clone()))
+        .collect();
+    base_edge_keys.extend(
+        refs.iter()
+            .map(|r| (r.from.0.clone(), r.to.0.clone(), DependencyKind::Data)),
+    );
+
+    for e in &pdg.edges {
+        let key = (e.from.clone(), e.to.clone(), e.kind.clone());
+        if base_edge_keys.contains(&key) {
+            continue;
+        }
+        let (file, line, derived_certainty) =
+            edge_location_from_nodes(&e.from, &e.to, &nodes_by_id, &callsite_certainty_by_loc);
+        push_ref(Reference {
+            from: SymbolId(e.from.clone()),
+            to: SymbolId(e.to.clone()),
+            kind: ref_kind_from_dependency(&e.kind),
+            file,
+            line,
+            certainty: derived_certainty.unwrap_or(EdgeCertainty::Inferred),
+            provenance: EdgeProvenance::SymbolicPropagation,
+        });
+    }
+
+    merged
+}
+
 fn run_impact(
     fmt: OutputFormat,
     lang_opt: LangOpt,
@@ -1226,36 +1368,7 @@ fn run_impact(
                 println!("{}", dfg_to_dot(&pdg));
                 return Ok(());
             }
-            let confirmed_pairs: std::collections::HashSet<(String, String)> = refs
-                .iter()
-                .filter(|r| {
-                    matches!(
-                        r.certainty,
-                        dimpact::ir::reference::EdgeCertainty::Confirmed
-                    )
-                })
-                .map(|r| (r.from.0.clone(), r.to.0.clone()))
-                .collect();
-            let pdg_refs: Vec<Reference> = pdg
-                .edges
-                .into_iter()
-                .map(|e| {
-                    let pair = (e.from.clone(), e.to.clone());
-                    let certainty = if confirmed_pairs.contains(&pair) {
-                        dimpact::ir::reference::EdgeCertainty::Confirmed
-                    } else {
-                        dimpact::ir::reference::EdgeCertainty::Inferred
-                    };
-                    Reference {
-                        from: SymbolId(e.from),
-                        to: SymbolId(e.to),
-                        kind: RefKind::Call,
-                        file: String::new(),
-                        line: 0,
-                        certainty,
-                    }
-                })
-                .collect();
+            let pdg_refs = merge_pdg_references(&combined, &pdg, &refs);
             let (out, confidence_filter) = apply_confidence_filter(
                 compute_impact(&changed.changed_symbols, &index, &pdg_refs, &opts),
                 &opts,
@@ -1327,36 +1440,7 @@ fn run_impact(
         if with_propagation {
             PdgBuilder::augment_symbolic_propagation(&mut pdg, &refs, &index);
         }
-        let confirmed_pairs: std::collections::HashSet<(String, String)> = refs
-            .iter()
-            .filter(|r| {
-                matches!(
-                    r.certainty,
-                    dimpact::ir::reference::EdgeCertainty::Confirmed
-                )
-            })
-            .map(|r| (r.from.0.clone(), r.to.0.clone()))
-            .collect();
-        let pdg_refs: Vec<Reference> = pdg
-            .edges
-            .into_iter()
-            .map(|e| {
-                let pair = (e.from.clone(), e.to.clone());
-                let certainty = if confirmed_pairs.contains(&pair) {
-                    dimpact::ir::reference::EdgeCertainty::Confirmed
-                } else {
-                    dimpact::ir::reference::EdgeCertainty::Inferred
-                };
-                Reference {
-                    from: SymbolId(e.from),
-                    to: SymbolId(e.to),
-                    kind: RefKind::Call,
-                    file: String::new(),
-                    line: 0,
-                    certainty,
-                }
-            })
-            .collect();
+        let pdg_refs = merge_pdg_references(&combined, &pdg, &refs);
         let (out, confidence_filter) = apply_confidence_filter(
             compute_impact(&seeds, &index, &pdg_refs, &opts),
             &opts,
@@ -1741,6 +1825,103 @@ mod tests {
         unsafe {
             std::env::remove_var("DIMPACT_AUTO_POLICY");
         }
+    }
+
+    #[test]
+    fn merge_pdg_references_preserves_kind_certainty_and_provenance() {
+        let combined = DataFlowGraph {
+            nodes: vec![
+                dimpact::dfg::DfgNode {
+                    id: "f.rs:def:x:10".to_string(),
+                    name: "x".to_string(),
+                    file: "f.rs".to_string(),
+                    line: 10,
+                },
+                dimpact::dfg::DfgNode {
+                    id: "f.rs:use:x:10".to_string(),
+                    name: "x".to_string(),
+                    file: "f.rs".to_string(),
+                    line: 10,
+                },
+                dimpact::dfg::DfgNode {
+                    id: "f.rs:def:y:10".to_string(),
+                    name: "y".to_string(),
+                    file: "f.rs".to_string(),
+                    line: 10,
+                },
+                dimpact::dfg::DfgNode {
+                    id: "f.rs:ctrl:9:10".to_string(),
+                    name: "control".to_string(),
+                    file: "f.rs".to_string(),
+                    line: 9,
+                },
+            ],
+            edges: vec![
+                dimpact::dfg::DfgEdge {
+                    from: "f.rs:def:x:10".to_string(),
+                    to: "f.rs:use:x:10".to_string(),
+                    kind: DependencyKind::Data,
+                },
+                dimpact::dfg::DfgEdge {
+                    from: "f.rs:ctrl:9:10".to_string(),
+                    to: "f.rs:def:y:10".to_string(),
+                    kind: DependencyKind::Control,
+                },
+            ],
+        };
+        let refs = vec![Reference {
+            from: SymbolId("rust:f.rs:fn:caller:9".to_string()),
+            to: SymbolId("rust:f.rs:fn:callee:1".to_string()),
+            kind: RefKind::Call,
+            file: "f.rs".to_string(),
+            line: 10,
+            certainty: EdgeCertainty::Confirmed,
+            provenance: EdgeProvenance::CallGraph,
+        }];
+        let mut pdg = combined.clone();
+        pdg.edges.push(dimpact::dfg::DfgEdge {
+            from: refs[0].from.0.clone(),
+            to: refs[0].to.0.clone(),
+            kind: DependencyKind::Data,
+        });
+        pdg.edges.push(dimpact::dfg::DfgEdge {
+            from: "f.rs:use:x:10".to_string(),
+            to: "f.rs:def:y:10".to_string(),
+            kind: DependencyKind::Data,
+        });
+
+        let merged = merge_pdg_references(&combined, &pdg, &refs);
+
+        assert!(merged.iter().any(|r| {
+            r.kind == RefKind::Call
+                && r.provenance == EdgeProvenance::CallGraph
+                && r.certainty == EdgeCertainty::Confirmed
+                && r.file == "f.rs"
+                && r.line == 10
+        }));
+        assert!(merged.iter().any(|r| {
+            r.kind == RefKind::Data
+                && r.provenance == EdgeProvenance::LocalDfg
+                && r.certainty == EdgeCertainty::Inferred
+                && r.from.0 == "f.rs:def:x:10"
+                && r.to.0 == "f.rs:use:x:10"
+        }));
+        assert!(merged.iter().any(|r| {
+            r.kind == RefKind::Control
+                && r.provenance == EdgeProvenance::LocalDfg
+                && r.certainty == EdgeCertainty::Inferred
+                && r.from.0 == "f.rs:ctrl:9:10"
+                && r.to.0 == "f.rs:def:y:10"
+        }));
+        assert!(merged.iter().any(|r| {
+            r.kind == RefKind::Data
+                && r.provenance == EdgeProvenance::SymbolicPropagation
+                && r.certainty == EdgeCertainty::Confirmed
+                && r.file == "f.rs"
+                && r.line == 10
+                && r.from.0 == "f.rs:use:x:10"
+                && r.to.0 == "f.rs:def:y:10"
+        }));
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -506,6 +506,7 @@ pub fn load_graph(conn: &Connection) -> anyhow::Result<(SymbolIndex, Vec<Referen
             file,
             line: line as u32,
             certainty: crate::ir::reference::EdgeCertainty::Inferred,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         })
     })?;
     let mut edges = Vec::new();

--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -1090,6 +1090,7 @@ mod pdg_tests {
             file: "f.rs".to_string(),
             line: 10,
             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         };
         let dfg = DataFlowGraph {
             nodes: Vec::new(),
@@ -1132,6 +1133,7 @@ mod pdg_tests {
             file: "f.rs".to_string(),
             line: 10,
             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         };
         let pdg = PdgBuilder::build(&dfg, std::slice::from_ref(&ref_sym));
         // Check call edge added
@@ -1189,6 +1191,7 @@ mod pdg_tests {
             file: "f.rs".to_string(),
             line: 10,
             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         }];
         let index = crate::ir::reference::SymbolIndex::build(vec![Symbol {
             id: SymbolId("rust:f.rs:fn:callee:1".to_string()),
@@ -1272,6 +1275,7 @@ mod pdg_tests {
             file: "f.rs".to_string(),
             line: 10,
             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         }];
         let index = crate::ir::reference::SymbolIndex::build(vec![Symbol {
             id: SymbolId("rust:f.rs:fn:callee:1".to_string()),

--- a/src/engine/lsp.rs
+++ b/src/engine/lsp.rs
@@ -1859,7 +1859,8 @@ fn scan_and_enqueue_callees(
                                                     kind: crate::ir::reference::RefKind::Call,
                                                     file: cur_sym.file.clone(),
                                                     line: li as u32 + 1,
-                                                certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                                                    certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                                                    provenance: crate::ir::reference::EdgeProvenance::CallGraph,
                                                 });
                                                 added += 1;
                                             }
@@ -1995,6 +1996,7 @@ fn enqueue_callers_via_references(
                             file: sym_from.file.clone(),
                             line: sym_from.range.start_line,
                             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
                         });
                     }
                 }
@@ -2132,6 +2134,7 @@ fn scan_callees_symbols(
                                     file: cur_sym.file.clone(),
                                     line: li as u32 + 1,
                                     certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                                    provenance: crate::ir::reference::EdgeProvenance::CallGraph,
                                 });
                             }
                         }
@@ -2217,6 +2220,7 @@ fn enqueue_edge(
             file: from.file.clone(),
             line: from.range.start_line,
             certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+            provenance: crate::ir::reference::EdgeProvenance::CallGraph,
         });
     }
 }
@@ -2348,6 +2352,7 @@ fn lsp_impact_references_build(
                         file: caller.file.clone(),
                         line: caller.range.start_line,
                         certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                        provenance: crate::ir::reference::EdgeProvenance::CallGraph,
                     });
                 }
                 if queued_nodes.insert(caller.id.0.clone()) {
@@ -2899,6 +2904,7 @@ fn lsp_build_project_graph(
                     file: caller.file.clone(),
                     line: caller.range.start_line,
                     certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                    provenance: crate::ir::reference::EdgeProvenance::CallGraph,
                 });
             }
         }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -594,6 +594,7 @@ pub(crate) fn resolve_references(
                 file: r.file.clone(),
                 line: r.line,
                 certainty: crate::ir::reference::EdgeCertainty::Inferred,
+                provenance: crate::ir::reference::EdgeProvenance::CallGraph,
             });
         }
     }

--- a/src/ir/reference.rs
+++ b/src/ir/reference.rs
@@ -1,10 +1,21 @@
 use crate::ir::{Symbol, SymbolId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum RefKind {
     Call,
+    Data,
+    Control,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeProvenance {
+    #[default]
+    CallGraph,
+    LocalDfg,
+    SymbolicPropagation,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -17,7 +28,7 @@ pub struct UnresolvedRef {
     pub is_method: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum EdgeCertainty {
     #[default]
@@ -34,6 +45,7 @@ pub struct Reference {
     pub file: String,
     pub line: u32,
     pub certainty: EdgeCertainty,
+    pub provenance: EdgeProvenance,
 }
 
 #[derive(Serialize)]
@@ -45,6 +57,7 @@ struct ReferenceSer<'a> {
     line: u32,
     certainty: &'a EdgeCertainty,
     confidence: &'a EdgeCertainty,
+    provenance: &'a EdgeProvenance,
 }
 
 #[derive(Deserialize)]
@@ -58,6 +71,8 @@ struct ReferenceDe {
     certainty: Option<EdgeCertainty>,
     #[serde(default)]
     confidence: Option<EdgeCertainty>,
+    #[serde(default)]
+    provenance: EdgeProvenance,
 }
 
 impl Serialize for Reference {
@@ -73,6 +88,7 @@ impl Serialize for Reference {
             line: self.line,
             certainty: &self.certainty,
             confidence: &self.certainty,
+            provenance: &self.provenance,
         }
         .serialize(serializer)
     }
@@ -91,6 +107,7 @@ impl<'de> Deserialize<'de> for Reference {
             file: raw.file,
             line: raw.line,
             certainty: raw.certainty.or(raw.confidence).unwrap_or_default(),
+            provenance: raw.provenance,
         })
     }
 }
@@ -147,6 +164,7 @@ mod tests {
             file: "src/lib.rs".to_string(),
             line: 42,
             certainty,
+            provenance: EdgeProvenance::CallGraph,
         }
     }
 
@@ -157,6 +175,7 @@ mod tests {
 
         assert_eq!(v["certainty"], "dynamic_fallback");
         assert_eq!(v["confidence"], "dynamic_fallback");
+        assert_eq!(v["provenance"], "call_graph");
     }
 
     #[test]
@@ -221,5 +240,21 @@ confidence: inferred
         let out = serde_yaml::to_string(&r).expect("yaml serialize");
         assert!(out.contains("certainty: inferred"));
         assert!(out.contains("confidence: inferred"));
+        assert!(out.contains("provenance: call_graph"));
+    }
+
+    #[test]
+    fn deserialize_defaults_provenance_to_call_graph() {
+        let raw = serde_json::json!({
+            "from": "a::f",
+            "to": "b::g",
+            "kind": "call",
+            "file": "src/lib.rs",
+            "line": 42,
+            "certainty": "confirmed"
+        });
+
+        let r: Reference = serde_json::from_value(raw).expect("deserialize reference");
+        assert_eq!(r.provenance, EdgeProvenance::CallGraph);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -128,6 +128,7 @@ mod impact_render_tests {
                 file: "f.rs".into(),
                 line: 2,
                 certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                provenance: crate::ir::reference::EdgeProvenance::CallGraph,
             },
             Reference {
                 from: b.id.clone(),
@@ -136,6 +137,7 @@ mod impact_render_tests {
                 file: "f.rs".into(),
                 line: 3,
                 certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                provenance: crate::ir::reference::EdgeProvenance::CallGraph,
             },
         ];
         let out = ImpactOutput {
@@ -413,13 +415,27 @@ mod html {
                     crate::ir::reference::EdgeCertainty::Inferred => "inferred",
                     crate::ir::reference::EdgeCertainty::DynamicFallback => "dynamic_fallback",
                 };
+                let kind = match e.kind {
+                    crate::ir::reference::RefKind::Call => "call",
+                    crate::ir::reference::RefKind::Data => "data",
+                    crate::ir::reference::RefKind::Control => "control",
+                };
+                let provenance = match e.provenance {
+                    crate::ir::reference::EdgeProvenance::CallGraph => "call_graph",
+                    crate::ir::reference::EdgeProvenance::LocalDfg => "local_dfg",
+                    crate::ir::reference::EdgeProvenance::SymbolicPropagation => {
+                        "symbolic_propagation"
+                    }
+                };
                 edges.push(json!({
                     "data": {
                         "id": format!("{}->{}", e.from.0, e.to.0),
                         "source": e.from.0,
                         "target": e.to.0,
+                        "kind": kind,
                         "certainty": certainty,
                         "confidence": certainty,
+                        "provenance": provenance,
                     }
                 }));
 
@@ -501,7 +517,7 @@ mod html {
                 return String::new();
             }
             let mut buf = String::from(
-                "<div class=\"sec card\"><h2>Edges</h2><table><thead><tr><th>From</th><th>To</th><th>Certainty</th></tr></thead><tbody>",
+                "<div class=\"sec card\"><h2>Edges</h2><table><thead><tr><th>From</th><th>To</th><th>Kind</th><th>Certainty</th><th>Provenance</th></tr></thead><tbody>",
             );
             for e in &self.out.edges {
                 let certainty = match e.certainty {
@@ -509,11 +525,25 @@ mod html {
                     crate::ir::reference::EdgeCertainty::Inferred => "inferred",
                     crate::ir::reference::EdgeCertainty::DynamicFallback => "dynamic_fallback",
                 };
+                let kind = match e.kind {
+                    crate::ir::reference::RefKind::Call => "call",
+                    crate::ir::reference::RefKind::Data => "data",
+                    crate::ir::reference::RefKind::Control => "control",
+                };
+                let provenance = match e.provenance {
+                    crate::ir::reference::EdgeProvenance::CallGraph => "call_graph",
+                    crate::ir::reference::EdgeProvenance::LocalDfg => "local_dfg",
+                    crate::ir::reference::EdgeProvenance::SymbolicPropagation => {
+                        "symbolic_propagation"
+                    }
+                };
                 buf.push_str(&format!(
-                    "<tr><td><code>{}</code></td><td><code>{}</code></td><td>{}</td></tr>",
+                    "<tr><td><code>{}</code></td><td><code>{}</code></td><td>{}</td><td>{}</td><td>{}</td></tr>",
                     h(&e.from.0),
                     h(&e.to.0),
-                    h(certainty)
+                    h(kind),
+                    h(certainty),
+                    h(provenance)
                 ));
             }
             buf.push_str("</tbody></table></div>");

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -135,6 +135,14 @@ fn pdg_path_assigns_confirmed_or_inferred_confidence_only() {
         .iter()
         .filter_map(|e| e["certainty"].as_str().map(|s| s.to_string()))
         .collect();
+    let kinds: std::collections::BTreeSet<String> = edges
+        .iter()
+        .filter_map(|e| e["kind"].as_str().map(|s| s.to_string()))
+        .collect();
+    let provenances: std::collections::BTreeSet<String> = edges
+        .iter()
+        .filter_map(|e| e["provenance"].as_str().map(|s| s.to_string()))
+        .collect();
 
     assert!(
         certainties
@@ -146,6 +154,26 @@ fn pdg_path_assigns_confirmed_or_inferred_confidence_only() {
     assert!(
         !certainties.contains("dynamic_fallback"),
         "PDG path should not emit dynamic_fallback certainty"
+    );
+    assert!(
+        kinds.contains("call"),
+        "expected merged call edges: {:?}",
+        kinds
+    );
+    assert!(
+        kinds.contains("data"),
+        "expected merged data edges: {:?}",
+        kinds
+    );
+    assert!(
+        provenances.contains("call_graph"),
+        "expected call_graph provenance: {:?}",
+        provenances
+    );
+    assert!(
+        provenances.contains("symbolic_propagation"),
+        "expected symbolic_propagation provenance: {:?}",
+        provenances
     );
 }
 


### PR DESCRIPTION
## Summary
- keep PDG-path call graph edges as call edges instead of collapsing everything to call/inferred/line 0
- merge local DFG and symbolic propagation edges into the main impact result with explicit kind, certainty, and provenance metadata
- expose the new edge metadata in reference serialization and report rendering, with regression coverage for the merged PDG path

## Testing
- cargo fmt --all
- cargo test --quiet --test cli_pdg_propagation
- cargo test --quiet merge_pdg_references_preserves_kind_certainty_and_provenance --bin dimpact
- cargo test --quiet ir::reference::tests --lib
- cargo test --quiet