### PR TITLE
feat: bridge imported result alias chains

### DIFF
--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -577,6 +577,64 @@ fn push_unique_edge(
     }
 }
 
+fn push_one_hop_completion_bridges(
+    pdg: &mut DataFlowGraph,
+    seen_edges: &mut std::collections::HashSet<(String, String, DependencyKind)>,
+    outer_callee_id: &str,
+    impacted_node_ids: &[String],
+    callsite_defs: &[String],
+    refs: &[Reference],
+    summary_by_fn: &std::collections::HashMap<String, FunctionSummary>,
+    node_loc_by_id: &std::collections::HashMap<String, (String, u32)>,
+) {
+    if callsite_defs.is_empty() {
+        return;
+    }
+
+    for impacted in impacted_node_ids {
+        let Some((file, line)) = node_loc_by_id.get(impacted) else {
+            continue;
+        };
+        for nested_ref in refs.iter().filter(|nested| {
+            nested.kind == crate::ir::reference::RefKind::Call
+                && nested.provenance == crate::ir::reference::EdgeProvenance::CallGraph
+                && nested.from.0 == outer_callee_id
+                && nested.file == *file
+                && nested.line == *line
+        }) {
+            let Some(nested_summary) = summary_by_fn.get(&nested_ref.to.0) else {
+                continue;
+            };
+            if nested_summary.inputs.len() != 1 {
+                continue;
+            }
+            let nested_input = nested_summary.inputs[0].clone();
+            push_unique_edge(
+                pdg,
+                seen_edges,
+                impacted.clone(),
+                nested_input.clone(),
+                DependencyKind::Data,
+            );
+            for nested_flow in nested_summary.flows.iter().filter(|flow| {
+                flow.input_node_id == nested_input && !flow.impacted_node_ids.is_empty()
+            }) {
+                for nested_impacted in &nested_flow.impacted_node_ids {
+                    for d in callsite_defs {
+                        push_unique_edge(
+                            pdg,
+                            seen_edges,
+                            nested_impacted.clone(),
+                            d.clone(),
+                            DependencyKind::Data,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl PdgBuilder {
     /// Build a PDG by combining the data/control flow graph and call references.
     pub fn build(dfg: &DataFlowGraph, refs: &[Reference]) -> DataFlowGraph {
@@ -627,6 +685,11 @@ impl PdgBuilder {
             .iter()
             .map(|e| (e.from.clone(), e.to.clone(), e.kind.clone()))
             .collect();
+        let node_loc_by_id: std::collections::HashMap<String, (String, u32)> = pdg
+            .nodes
+            .iter()
+            .map(|node| (node.id.clone(), (node.file.clone(), node.line)))
+            .collect();
 
         // Precompute minimal function summaries and map by callee symbol ID.
         let summaries = Self::build_function_summaries(pdg, index);
@@ -637,7 +700,10 @@ impl PdgBuilder {
         }
 
         // 1) Call-site bridges + summary-connected inter-procedural bridges
-        for r in refs {
+        for r in refs.iter().filter(|r| {
+            r.kind == crate::ir::reference::RefKind::Call
+                && r.provenance == crate::ir::reference::EdgeProvenance::CallGraph
+        }) {
             let key = (r.file.clone(), r.line);
             let callsite_uses = uses_by_loc.get(&key).cloned().unwrap_or_default();
             let callsite_defs = defs_by_loc.get(&key).cloned().unwrap_or_default();
@@ -702,6 +768,16 @@ impl PdgBuilder {
                                 );
                             }
                         }
+                        push_one_hop_completion_bridges(
+                            pdg,
+                            &mut seen_edges,
+                            r.to.0.as_str(),
+                            &flow.impacted_node_ids,
+                            &callsite_defs,
+                            refs,
+                            &summary_by_fn,
+                            &node_loc_by_id,
+                        );
                         if callsite_defs.len() == 1 {
                             push_unique_edge(
                                 pdg,
@@ -733,6 +809,16 @@ impl PdgBuilder {
                                 );
                             }
                         }
+                        push_one_hop_completion_bridges(
+                            pdg,
+                            &mut seen_edges,
+                            r.to.0.as_str(),
+                            &flow.impacted_node_ids,
+                            &callsite_defs,
+                            refs,
+                            &summary_by_fn,
+                            &node_loc_by_id,
+                        );
                     }
                     if callsite_defs.len() == 1 {
                         push_unique_edge(

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -247,6 +247,68 @@ fn caller() {
     (dir, path)
 }
 
+fn setup_cross_file_imported_result_alias_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::write(
+        path.join("value.rs"),
+        r#"pub fn make(a: i32) -> i32 {
+    a + 1
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("adapter.rs"),
+        r#"use crate::value;
+
+pub fn wrap(a: i32) -> i32 {
+    value::make(a)
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("main.rs"),
+        r#"mod value;
+mod adapter;
+
+fn caller() {
+    let x = 1;
+    let y = adapter::wrap(x);
+    let alias = y;
+    let out = alias;
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("main.rs"),
+        r#"mod value;
+mod adapter;
+
+fn caller() {
+    let x = 2;
+    let y = adapter::wrap(x);
+    let alias = y;
+    let out = alias;
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_ruby_require_relative_alias_return_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -621,6 +683,60 @@ fn pdg_propagation_maps_multi_file_wrapper_return_without_leaking_irrelevant_arg
     assert!(
         !prop.contains("\"main.rs:use:x:7\" -> \"main.rs:def:out:7\""),
         "unexpected irrelevant arg bridge leaked through wrapper summary, got:\n{}",
+        prop
+    );
+}
+
+#[test]
+fn pdg_propagation_extends_imported_result_into_caller_alias_chain() {
+    let (_tmp, repo) = setup_cross_file_imported_result_alias_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &["--direction", "callees", "--with-pdg", "--format", "dot"],
+    );
+    let prop = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--with-propagation",
+            "--format",
+            "dot",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"value.rs:def:a:1\""),
+        "expected bounded slice builder to include third-file callee DFG nodes in plain PDG scope, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"value.rs:use:a:2\" -> \"main.rs:def:y:6\""),
+        "plain PDG should not synthesize the imported-result bridge into the caller alias chain, got:\n{}",
+        pdg
+    );
+    assert!(
+        prop.contains("\"adapter.rs:use:a:4\" -> \"value.rs:def:a:1\""),
+        "expected propagation to bridge the boundary callsite into the completion callee input, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"value.rs:use:a:2\" -> \"main.rs:def:y:6\""),
+        "expected propagation to carry the imported result back into caller def y, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"main.rs:def:y:6\" -> \"main.rs:def:alias:7\""),
+        "expected caller-side alias chain to remain connected after the imported result bridge, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"main.rs:def:alias:7\" -> \"main.rs:def:out:8\""),
+        "expected caller-side alias continuation to reach the final output def, got:\n{}",
         prop
     );
 }


### PR DESCRIPTION
## Summary
- add one-hop nested summary completion for propagation so a direct boundary call can bridge through a single nested callee
- improve the three-file imported-result alias case so the callee result reaches the caller-side alias chain
- add a focused CLI propagation regression for the new Rust multi-file alias bridge

## Testing
- cargo test --test cli_pdg_propagation pdg_propagation_extends_imported_result_into_caller_alias_chain -- --nocapture
- cargo test

Task: G5-5