### PR TITLE
feat: split bounded slice explanation scope

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1069,22 +1069,39 @@ struct SliceSelectionAccumulator {
 }
 
 impl SliceSelectionAccumulator {
-    fn select_path(&mut self, path: &str) {
+    fn mark_cache_update(&mut self, path: &str) {
         self.cache_update_paths.insert(path.to_string());
         let file_state = self.files.entry(path.to_string()).or_default();
         file_state.scopes.cache_update = true;
-        file_state.scopes.explanation = true;
+    }
+
+    fn mark_local_dfg(&mut self, path: &str) {
+        self.mark_cache_update(path);
         if supports_local_dfg(path) {
             self.local_dfg_paths.insert(path.to_string());
+            let file_state = self.files.entry(path.to_string()).or_default();
             file_state.scopes.local_dfg = true;
         }
     }
 
+    fn mark_explanation(&mut self, path: &str) {
+        self.mark_cache_update(path);
+        let file_state = self.files.entry(path.to_string()).or_default();
+        file_state.scopes.explanation = true;
+    }
+
     fn add_reason(&mut self, path: &str, reason: ImpactSliceReasonMetadata) {
-        self.select_path(path);
+        self.mark_explanation(path);
+        if supports_local_dfg(path) {
+            self.mark_local_dfg(path);
+        }
         if let Some(file_state) = self.files.get_mut(path) {
             file_state.reasons.insert(reason);
         }
+    }
+
+    fn add_pruned_candidate(&mut self, candidate: dimpact::ImpactSlicePrunedCandidate) {
+        self.pruned_candidates.insert(candidate);
     }
 
     fn merge(&mut self, other: &SliceSelectionAccumulator) {
@@ -1440,10 +1457,10 @@ fn plan_bounded_slice(
     let mut overall = SliceSelectionAccumulator::default();
 
     for path in cache_update_roots {
-        overall.select_path(path);
+        overall.mark_cache_update(path);
     }
     for path in local_dfg_roots {
-        overall.select_path(path);
+        overall.mark_local_dfg(path);
     }
     let symbol_file_by_id: std::collections::HashMap<_, _> = index
         .symbols
@@ -1583,13 +1600,11 @@ fn plan_bounded_slice(
                 .iter()
                 .skip(PER_BOUNDARY_SIDE_TIER2_FILES_MAX)
             {
-                seed_selection
-                    .pruned_candidates
-                    .insert(make_tier2_pruned_candidate(
-                        seed.id.0.as_str(),
-                        candidate,
-                        ImpactSlicePruneReason::RankedOut,
-                    ));
+                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                    seed.id.0.as_str(),
+                    candidate,
+                    ImpactSlicePruneReason::RankedOut,
+                ));
             }
             tier2_candidates.extend(
                 side_candidates
@@ -1609,13 +1624,11 @@ fn plan_bounded_slice(
                 continue;
             }
             if selected_tier2_paths.len() >= PER_SEED_TIER2_FILES_MAX {
-                seed_selection
-                    .pruned_candidates
-                    .insert(make_tier2_pruned_candidate(
-                        seed.id.0.as_str(),
-                        &candidate,
-                        ImpactSlicePruneReason::BridgeBudgetExhausted,
-                    ));
+                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                    seed.id.0.as_str(),
+                    &candidate,
+                    ImpactSlicePruneReason::BridgeBudgetExhausted,
+                ));
                 continue;
             }
             seed_selection.add_reason(
@@ -3303,6 +3316,58 @@ fn caller() -> i32 {
 
         assert!(plan.cache_update_paths.contains(&"helper.js".to_string()));
         assert_eq!(plan.local_dfg_paths, vec!["main.rs".to_string()]);
+    }
+
+    #[test]
+    fn bounded_slice_plan_keeps_initial_local_dfg_roots_out_of_explanation_scope_without_reasons() {
+        let seed = test_symbol("rust:main.rs:fn:caller:1", "caller", "main.rs", 1);
+        let callee = test_symbol("rust:callee.rs:fn:callee:1", "callee", "callee.rs", 1);
+        let index = SymbolIndex::build(vec![seed.clone(), callee.clone()]);
+        let refs = vec![call_ref(
+            seed.id.0.as_str(),
+            callee.id.0.as_str(),
+            "main.rs",
+            4,
+        )];
+
+        let plan = plan_bounded_slice(
+            &[seed.file.clone(), "notes.rs".to_string()],
+            &[seed.file.clone(), "notes.rs".to_string()],
+            std::slice::from_ref(&seed),
+            &index,
+            &refs,
+            ImpactDirection::Callees,
+            ImpactSliceReasonKind::SeedFile,
+        );
+
+        let notes = slice_selection_file(&plan.slice_selection, "notes.rs");
+        assert_eq!(
+            notes.scopes,
+            ImpactSliceScopes {
+                cache_update: true,
+                local_dfg: true,
+                explanation: false,
+            }
+        );
+        assert!(
+            notes.reasons.is_empty(),
+            "notes.rs should stay cache/local-DFG only"
+        );
+
+        let main = slice_selection_file(&plan.slice_selection, "main.rs");
+        assert!(main.scopes.explanation);
+        assert_eq!(
+            main.reasons,
+            vec![ImpactSliceReasonMetadata {
+                seed_symbol_id: seed.id.0.clone(),
+                tier: 0,
+                kind: ImpactSliceReasonKind::SeedFile,
+                via_symbol_id: None,
+                via_path: None,
+                bridge_kind: None,
+                scoring: None,
+            }]
+        );
     }
 
     #[test]

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -629,6 +629,7 @@ fn build_witness_slice_context(
     let selected_files_by_path: HashMap<&str, &ImpactSliceFileMetadata> = slice_selection
         .files
         .iter()
+        .filter(|file| file.scopes.explanation)
         .map(|file| (file.path.as_str(), file))
         .collect();
 
@@ -2166,6 +2167,237 @@ fn foo() { bar(); }
                             via_symbol_id: Some(mid.id.0.clone()),
                             via_path: None,
                             bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                            scoring: None,
+                        }],
+                    },
+                    ImpactWitnessSliceFileContext {
+                        path: "callee.rs".to_string(),
+                        witness_hops: vec![1],
+                        selection_reasons: vec![ImpactSliceReasonMetadata {
+                            seed_symbol_id: seed.id.0.clone(),
+                            tier: 1,
+                            kind: ImpactSliceReasonKind::DirectCalleeFile,
+                            via_symbol_id: Some(target.id.0.clone()),
+                            via_path: None,
+                            bridge_kind: None,
+                            scoring: None,
+                        }],
+                        seed_reasons: vec![ImpactSliceReasonMetadata {
+                            seed_symbol_id: seed.id.0.clone(),
+                            tier: 1,
+                            kind: ImpactSliceReasonKind::DirectCalleeFile,
+                            via_symbol_id: Some(target.id.0.clone()),
+                            via_path: None,
+                            bridge_kind: None,
+                            scoring: None,
+                        }],
+                    },
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn attach_slice_selection_summary_omits_non_explanation_files_from_witness_context() {
+        let seed = Symbol {
+            id: crate::ir::SymbolId::new(
+                "rust",
+                "main.rs",
+                &crate::ir::SymbolKind::Function,
+                "caller",
+                1,
+            ),
+            name: "caller".to_string(),
+            kind: crate::ir::SymbolKind::Function,
+            file: "main.rs".to_string(),
+            range: crate::ir::TextRange {
+                start_line: 1,
+                end_line: 1,
+            },
+            language: "rust".to_string(),
+        };
+        let mid = Symbol {
+            id: crate::ir::SymbolId::new(
+                "rust",
+                "wrapper.rs",
+                &crate::ir::SymbolKind::Function,
+                "wrap",
+                2,
+            ),
+            name: "wrap".to_string(),
+            kind: crate::ir::SymbolKind::Function,
+            file: "wrapper.rs".to_string(),
+            range: crate::ir::TextRange {
+                start_line: 2,
+                end_line: 2,
+            },
+            language: "rust".to_string(),
+        };
+        let target = Symbol {
+            id: crate::ir::SymbolId::new(
+                "rust",
+                "callee.rs",
+                &crate::ir::SymbolKind::Function,
+                "callee",
+                3,
+            ),
+            name: "callee".to_string(),
+            kind: crate::ir::SymbolKind::Function,
+            file: "callee.rs".to_string(),
+            range: crate::ir::TextRange {
+                start_line: 3,
+                end_line: 3,
+            },
+            language: "rust".to_string(),
+        };
+        let mut out = ImpactOutput {
+            changed_symbols: vec![seed.clone()],
+            impacted_symbols: vec![mid.clone(), target.clone()],
+            impacted_witnesses: HashMap::from([(
+                target.id.0.clone(),
+                ImpactWitness {
+                    symbol_id: target.id.0.clone(),
+                    depth: 1,
+                    root_symbol_id: seed.id.0.clone(),
+                    via_symbol_id: mid.id.0.clone(),
+                    edge: Reference {
+                        from: mid.id.clone(),
+                        to: target.id.clone(),
+                        kind: RefKind::Call,
+                        line: 11,
+                        file: "wrapper.rs".to_string(),
+                        certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                        provenance: EdgeProvenance::CallGraph,
+                    },
+                    path: vec![
+                        ImpactWitnessHop {
+                            from_symbol_id: seed.id.0.clone(),
+                            to_symbol_id: mid.id.0.clone(),
+                            edge: Reference {
+                                from: seed.id.clone(),
+                                to: mid.id.clone(),
+                                kind: RefKind::Call,
+                                line: 10,
+                                file: "main.rs".to_string(),
+                                certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                                provenance: EdgeProvenance::CallGraph,
+                            },
+                        },
+                        ImpactWitnessHop {
+                            from_symbol_id: mid.id.0.clone(),
+                            to_symbol_id: target.id.0.clone(),
+                            edge: Reference {
+                                from: mid.id.clone(),
+                                to: target.id.clone(),
+                                kind: RefKind::Call,
+                                line: 11,
+                                file: "wrapper.rs".to_string(),
+                                certainty: crate::ir::reference::EdgeCertainty::Confirmed,
+                                provenance: EdgeProvenance::CallGraph,
+                            },
+                        },
+                    ],
+                    provenance_chain: vec![],
+                    kind_chain: vec![],
+                    path_compact: vec![],
+                    provenance_chain_compact: vec![],
+                    kind_chain_compact: vec![],
+                    slice_context: None,
+                },
+            )]),
+            impacted_files: vec![],
+            edges: vec![],
+            impacted_by_file: HashMap::new(),
+            summary: ImpactSummary::default(),
+        };
+        let slice_selection = ImpactSliceSelectionSummary {
+            planner: ImpactSlicePlannerKind::BoundedSlice,
+            files: vec![
+                ImpactSliceFileMetadata {
+                    path: "main.rs".to_string(),
+                    scopes: ImpactSliceScopes {
+                        cache_update: true,
+                        local_dfg: true,
+                        explanation: true,
+                    },
+                    reasons: vec![ImpactSliceReasonMetadata {
+                        seed_symbol_id: seed.id.0.clone(),
+                        tier: 0,
+                        kind: ImpactSliceReasonKind::SeedFile,
+                        via_symbol_id: None,
+                        via_path: None,
+                        bridge_kind: None,
+                        scoring: None,
+                    }],
+                },
+                ImpactSliceFileMetadata {
+                    path: "wrapper.rs".to_string(),
+                    scopes: ImpactSliceScopes {
+                        cache_update: true,
+                        local_dfg: true,
+                        explanation: false,
+                    },
+                    reasons: vec![ImpactSliceReasonMetadata {
+                        seed_symbol_id: seed.id.0.clone(),
+                        tier: 2,
+                        kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                        via_symbol_id: Some(mid.id.0.clone()),
+                        via_path: None,
+                        bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                        scoring: None,
+                    }],
+                },
+                ImpactSliceFileMetadata {
+                    path: "callee.rs".to_string(),
+                    scopes: ImpactSliceScopes {
+                        cache_update: true,
+                        local_dfg: true,
+                        explanation: true,
+                    },
+                    reasons: vec![ImpactSliceReasonMetadata {
+                        seed_symbol_id: seed.id.0.clone(),
+                        tier: 1,
+                        kind: ImpactSliceReasonKind::DirectCalleeFile,
+                        via_symbol_id: Some(target.id.0.clone()),
+                        via_path: None,
+                        bridge_kind: None,
+                        scoring: None,
+                    }],
+                },
+            ],
+            pruned_candidates: Vec::new(),
+        };
+
+        attach_slice_selection_summary(&mut out, &slice_selection);
+
+        let witness = out
+            .impacted_witnesses
+            .get(&target.id.0)
+            .expect("witness for callee");
+        assert_eq!(
+            witness.slice_context,
+            Some(ImpactWitnessSliceContext {
+                seed_symbol_id: seed.id.0.clone(),
+                selected_files_on_path: vec![
+                    ImpactWitnessSliceFileContext {
+                        path: "main.rs".to_string(),
+                        witness_hops: vec![0],
+                        selection_reasons: vec![ImpactSliceReasonMetadata {
+                            seed_symbol_id: seed.id.0.clone(),
+                            tier: 0,
+                            kind: ImpactSliceReasonKind::SeedFile,
+                            via_symbol_id: None,
+                            via_path: None,
+                            bridge_kind: None,
+                            scoring: None,
+                        }],
+                        seed_reasons: vec![ImpactSliceReasonMetadata {
+                            seed_symbol_id: seed.id.0.clone(),
+                            tier: 0,
+                            kind: ImpactSliceReasonKind::SeedFile,
+                            via_symbol_id: None,
+                            via_path: None,
+                            bridge_kind: None,
                             scoring: None,
                         }],
                     },


### PR DESCRIPTION
## Summary
- split bounded-slice scope marking into cache_update, local_dfg, and explanation responsibilities instead of treating explanation as a side effect of generic path selection
- keep initial cache/local-DFG roots selectable without automatically surfacing them as explanation files, while selected reasons still promote files into explanation scope
- filter witness slice context to explanation-visible files only and add regressions for the new scope behavior

## Testing
- cargo test --bin dimpact
- cargo test attach_slice_selection_summary_omits_non_explanation_files_from_witness_context --lib
- cargo test --test cli_pdg_propagation
- cargo test
- git diff --check