### PR TITLE
feat: improve ruby bridge scoring

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1221,6 +1221,44 @@ fn noise_keyword_hint(text: &str) -> bool {
         .any(|needle| text.contains(needle))
 }
 
+fn has_strong_semantic_tier2_evidence(primary_evidence_kinds: &[ImpactSliceEvidenceKind]) -> bool {
+    primary_evidence_kinds.iter().any(|kind| {
+        matches!(
+            kind,
+            ImpactSliceEvidenceKind::AliasChain | ImpactSliceEvidenceKind::ReturnFlow
+        )
+    })
+}
+
+fn ruby_require_relative_scoring_summary(
+    completion_file: &str,
+    call_line: u32,
+    side_max_call_line: u32,
+) -> ImpactSliceCandidateScoringSummary {
+    let mut primary_evidence_kinds = vec![ImpactSliceEvidenceKind::RequireRelativeEdge];
+    let mut secondary_evidence_kinds = Vec::new();
+    if call_line == side_max_call_line {
+        secondary_evidence_kinds.push(ImpactSliceEvidenceKind::CallsitePositionHint);
+    }
+    primary_evidence_kinds.sort_by_key(|kind| evidence_kind_key(*kind));
+    secondary_evidence_kinds.sort_by_key(|kind| evidence_kind_key(*kind));
+    let secondary_evidence_count = u8::try_from(secondary_evidence_kinds.len()).unwrap_or(u8::MAX);
+    ImpactSliceCandidateScoringSummary {
+        source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+        lane: ImpactSliceCandidateLane::RequireRelativeContinuation,
+        primary_evidence_kinds,
+        secondary_evidence_kinds,
+        score_tuple: ImpactSliceScoreTuple {
+            source_rank: 0,
+            lane_rank: tier2_lane_rank(ImpactSliceCandidateLane::RequireRelativeContinuation),
+            primary_evidence_count: 1,
+            secondary_evidence_count,
+            call_position_rank: call_line,
+            lexical_tiebreak: completion_file.to_string(),
+        },
+    }
+}
+
 fn evidence_kind_key(kind: ImpactSliceEvidenceKind) -> &'static str {
     match kind {
         ImpactSliceEvidenceKind::AliasChain => "alias_chain",
@@ -1263,32 +1301,8 @@ fn tier2_scoring_summary(
     call_line: u32,
     side_max_call_line: u32,
 ) -> ImpactSliceCandidateScoringSummary {
-    if boundary_file.ends_with(".rb") || completion_file.ends_with(".rb") {
-        let mut primary_evidence_kinds = vec![ImpactSliceEvidenceKind::RequireRelativeEdge];
-        let mut secondary_evidence_kinds = Vec::new();
-        if call_line == side_max_call_line {
-            secondary_evidence_kinds.push(ImpactSliceEvidenceKind::CallsitePositionHint);
-        }
-        primary_evidence_kinds.sort_by_key(|kind| evidence_kind_key(*kind));
-        secondary_evidence_kinds.sort_by_key(|kind| evidence_kind_key(*kind));
-        let secondary_evidence_count =
-            u8::try_from(secondary_evidence_kinds.len()).unwrap_or(u8::MAX);
-        return ImpactSliceCandidateScoringSummary {
-            source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
-            lane: ImpactSliceCandidateLane::RequireRelativeContinuation,
-            primary_evidence_kinds,
-            secondary_evidence_kinds,
-            score_tuple: ImpactSliceScoreTuple {
-                source_rank: 0,
-                lane_rank: tier2_lane_rank(ImpactSliceCandidateLane::RequireRelativeContinuation),
-                primary_evidence_count: 1,
-                secondary_evidence_count,
-                call_position_rank: call_line,
-                lexical_tiebreak: completion_file.to_string(),
-            },
-        };
-    }
-
+    let is_ruby_chain_candidate =
+        boundary_file.ends_with(".rb") || completion_file.ends_with(".rb");
     let boundary_name = boundary_symbol.name.to_ascii_lowercase();
     let boundary_path = boundary_file.to_ascii_lowercase();
     let completion_name = completion_symbol.name.to_ascii_lowercase();
@@ -1342,6 +1356,14 @@ fn tier2_scoring_summary(
         ImpactSliceCandidateLane::ModuleCompanionFallback => {
             primary_evidence_kinds.push(ImpactSliceEvidenceKind::ModuleCompanion);
         }
+    }
+
+    if is_ruby_chain_candidate && !has_strong_semantic_tier2_evidence(&primary_evidence_kinds) {
+        return ruby_require_relative_scoring_summary(
+            completion_file,
+            call_line,
+            side_max_call_line,
+        );
     }
 
     let mut secondary_evidence_kinds = Vec::new();
@@ -3200,6 +3222,126 @@ fn caller() -> i32 {
                         })
                 }),
             "expected later helper noise to lose to the stronger alias continuation candidate: {:#?}",
+            plan.slice_selection.pruned_candidates
+        );
+    }
+
+    #[test]
+    fn bounded_slice_plan_prefers_ruby_return_completion_over_later_require_relative_helper_noise()
+    {
+        let seed = test_symbol(
+            "ruby:app/runner.rb:method:entry:3",
+            "entry",
+            "app/runner.rb",
+            3,
+        );
+        let service = test_symbol(
+            "ruby:lib/service.rb:method:bounce:4",
+            "bounce",
+            "lib/service.rb",
+            4,
+        );
+        let leaf = test_symbol(
+            "ruby:lib/leaf.rb:method:finish:1",
+            "finish",
+            "lib/leaf.rb",
+            1,
+        );
+        let helper = test_symbol(
+            "ruby:lib/zzz_helper.rb:method:helper_noise:1",
+            "helper_noise",
+            "lib/zzz_helper.rb",
+            1,
+        );
+        let index = SymbolIndex::build(vec![
+            seed.clone(),
+            service.clone(),
+            leaf.clone(),
+            helper.clone(),
+        ]);
+        let refs = vec![
+            call_ref(
+                seed.id.0.as_str(),
+                service.id.0.as_str(),
+                "app/runner.rb",
+                5,
+            ),
+            call_ref(
+                service.id.0.as_str(),
+                leaf.id.0.as_str(),
+                "lib/service.rb",
+                6,
+            ),
+            call_ref(
+                service.id.0.as_str(),
+                helper.id.0.as_str(),
+                "lib/service.rb",
+                7,
+            ),
+        ];
+
+        let plan = plan_bounded_slice(
+            &[seed.file.clone()],
+            &[seed.file.clone()],
+            std::slice::from_ref(&seed),
+            &index,
+            &refs,
+            ImpactDirection::Callees,
+            ImpactSliceReasonKind::SeedFile,
+        );
+
+        assert_eq!(
+            plan.cache_update_paths,
+            vec![
+                "app/runner.rb".to_string(),
+                "lib/leaf.rb".to_string(),
+                "lib/service.rb".to_string(),
+            ]
+        );
+
+        let leaf_file = slice_selection_file(&plan.slice_selection, "lib/leaf.rb");
+        assert_eq!(
+            leaf_file.reasons,
+            vec![ImpactSliceReasonMetadata {
+                seed_symbol_id: seed.id.0.clone(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("ruby:lib/service.rb:method:bounce:4".to_string()),
+                via_path: Some("lib/service.rb".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                scoring: Some(test_tier2_scoring(
+                    ImpactSliceCandidateLane::ReturnContinuation,
+                    vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    vec![ImpactSliceEvidenceKind::NamePathHint],
+                    6,
+                    "lib/leaf.rb",
+                )),
+            }]
+        );
+        assert!(
+            plan.slice_selection
+                .pruned_candidates
+                .iter()
+                .any(|candidate| {
+                    candidate.path == "lib/zzz_helper.rb"
+                        && candidate.prune_reason == ImpactSlicePruneReason::RankedOut
+                        && candidate.bridge_kind
+                            == Some(ImpactSliceBridgeKind::RequireRelativeChain)
+                        && candidate.via_symbol_id.as_deref()
+                            == Some("ruby:lib/service.rb:method:bounce:4")
+                        && candidate.scoring.as_ref().is_some_and(|scoring| {
+                            scoring.lane == ImpactSliceCandidateLane::RequireRelativeContinuation
+                                && scoring.primary_evidence_kinds
+                                    == vec![ImpactSliceEvidenceKind::RequireRelativeEdge]
+                                && scoring.secondary_evidence_kinds
+                                    == vec![ImpactSliceEvidenceKind::CallsitePositionHint]
+                                && scoring.score_tuple.call_position_rank == 7
+                        })
+                }),
+            "expected later Ruby helper noise to stay a ranked-out require_relative fallback: {:#?}",
             plan.slice_selection.pruned_candidates
         );
     }

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -679,6 +679,78 @@ end
     (dir, path)
 }
 
+fn setup_ruby_require_relative_competing_leaf_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::create_dir_all(path.join("lib")).unwrap();
+    fs::create_dir_all(path.join("app")).unwrap();
+    fs::write(
+        path.join("lib/leaf.rb"),
+        r#"def finish(value)
+  alias_value = value
+  return alias_value
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/zzz_helper.rb"),
+        r#"def helper_noise(value)
+  debug_value = value.inspect
+  return debug_value
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/service.rb"),
+        r#"require_relative 'leaf'
+require_relative 'zzz_helper'
+
+def bounce(value)
+  alias_value = value
+  wrapped = finish(alias_value)
+  helper = helper_noise(value)
+  return wrapped
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("app/runner.rb"),
+        r#"require_relative '../lib/service'
+
+def entry(seed)
+  prepared = seed + 1
+  reply = bounce(prepared)
+  return reply
+end
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("app/runner.rb"),
+        r#"require_relative '../lib/service'
+
+def entry(seed)
+  prepared = seed + 2
+  reply = bounce(prepared)
+  return reply
+end
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn diff_text(repo: &std::path::Path) -> String {
     let diff_out = git(repo, &["diff", "--no-ext-diff", "--unified=0"]);
     String::from_utf8(diff_out.stdout).unwrap()
@@ -1270,6 +1342,145 @@ fn pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helpe
                         })
             })),
         "expected later helper noise to be preserved only as ranked-out metadata: {prop:#}"
+    );
+}
+
+#[test]
+fn pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise() {
+    let (_tmp, repo) = setup_ruby_require_relative_competing_leaf_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-pdg",
+            "--format",
+            "dot",
+        ],
+    );
+    let prop = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"lib/leaf.rb:def:alias_value:2\""),
+        "expected bounded slice scope to keep the semantic Ruby leaf file, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"lib/zzz_helper.rb:def:debug_value:2\""),
+        "unexpected later Ruby helper noise entered the bounded slice scope, got:\n{}",
+        pdg
+    );
+
+    let slice_selection = &prop["summary"]["slice_selection"];
+    let paths: Vec<&str> = slice_selection["files"]
+        .as_array()
+        .expect("slice_selection.files array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["app/runner.rb", "lib/leaf.rb", "lib/service.rb"]
+    );
+
+    let leaf = slice_selection_file(slice_selection, "lib/leaf.rb");
+    assert!(
+        leaf["reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason["tier"] == 2
+                    && reason["kind"] == "bridge_completion_file"
+                    && reason["via_symbol_id"] == "ruby:lib/service.rb:method:bounce:4"
+                    && reason["via_path"] == "lib/service.rb"
+                    && reason["bridge_kind"] == "wrapper_return"
+                    && reason["scoring"]
+                        == serde_json::json!({
+                            "source_kind": "graph_second_hop",
+                            "lane": "return_continuation",
+                            "primary_evidence_kinds": [
+                                "assigned_result",
+                                "return_flow"
+                            ],
+                            "secondary_evidence_kinds": [
+                                "name_path_hint"
+                            ],
+                            "score_tuple": {
+                                "source_rank": 0,
+                                "lane_rank": 0,
+                                "primary_evidence_count": 2,
+                                "secondary_evidence_count": 1,
+                                "call_position_rank": 6,
+                                "lexical_tiebreak": "lib/leaf.rb"
+                            }
+                        })
+            })),
+        "expected Ruby leaf to carry wrapper_return bridge metadata: {prop:#}"
+    );
+    assert!(
+        slice_selection["pruned_candidates"]
+            .as_array()
+            .is_some_and(|candidates| candidates.iter().any(|candidate| {
+                candidate["path"] == "lib/zzz_helper.rb"
+                    && candidate["prune_reason"] == "ranked_out"
+                    && candidate["via_symbol_id"] == "ruby:lib/service.rb:method:bounce:4"
+                    && candidate["bridge_kind"] == "require_relative_chain"
+                    && candidate["scoring"]
+                        == serde_json::json!({
+                            "source_kind": "graph_second_hop",
+                            "lane": "require_relative_continuation",
+                            "primary_evidence_kinds": [
+                                "require_relative_edge"
+                            ],
+                            "secondary_evidence_kinds": [
+                                "callsite_position_hint"
+                            ],
+                            "score_tuple": {
+                                "source_rank": 0,
+                                "lane_rank": 2,
+                                "primary_evidence_count": 1,
+                                "secondary_evidence_count": 1,
+                                "call_position_rank": 9,
+                                "lexical_tiebreak": "lib/zzz_helper.rb"
+                            }
+                        })
+            })),
+        "expected later Ruby helper noise to be preserved only as require_relative ranked-out metadata: {prop:#}"
+    );
+
+    let prop_dot = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "dot",
+        ],
+    );
+    assert!(
+        prop_dot.contains("\"app/runner.rb:use:prepared:5\" -> \"app/runner.rb:def:reply:5\""),
+        "expected propagation to recover the Ruby leaf-backed summary bridge, got:\n{}",
+        prop_dot
     );
 }
 


### PR DESCRIPTION
## Summary
- let Ruby tier2 bridge scoring keep semantic alias/return-flow evidence instead of collapsing every .rb candidate into require_relative scoring
- fall back to require_relative scoring only when a Ruby candidate lacks stronger semantic evidence
- add planner and CLI propagation regressions for a require_relative chain where a semantic leaf should beat later helper noise

## Testing
- cargo test --locked bounded_slice_plan_prefers_ruby_return_completion_over_later_require_relative_helper_noise --bin dimpact
- cargo test --locked --test cli_pdg_propagation pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise -- --exact
- cargo test --offline --bin dimpact
- cargo test --offline --test cli_pdg_propagation
- git diff --check