### PR TITLE
test: lock bridge scoring regression fixtures

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -3321,27 +3321,26 @@ fn caller() -> i32 {
                 )),
             }]
         );
-        assert!(
-            plan.slice_selection
-                .pruned_candidates
-                .iter()
-                .any(|candidate| {
-                    candidate.path == "lib/zzz_helper.rb"
-                        && candidate.prune_reason == ImpactSlicePruneReason::RankedOut
-                        && candidate.bridge_kind
-                            == Some(ImpactSliceBridgeKind::RequireRelativeChain)
-                        && candidate.via_symbol_id.as_deref()
-                            == Some("ruby:lib/service.rb:method:bounce:4")
-                        && candidate.scoring.as_ref().is_some_and(|scoring| {
-                            scoring.lane == ImpactSliceCandidateLane::RequireRelativeContinuation
-                                && scoring.primary_evidence_kinds
-                                    == vec![ImpactSliceEvidenceKind::RequireRelativeEdge]
-                                && scoring.secondary_evidence_kinds
-                                    == vec![ImpactSliceEvidenceKind::CallsitePositionHint]
-                                && scoring.score_tuple.call_position_rank == 7
-                        })
-                }),
-            "expected later Ruby helper noise to stay a ranked-out require_relative fallback: {:#?}",
+        assert_eq!(
+            plan.slice_selection.pruned_candidates,
+            vec![dimpact::ImpactSlicePrunedCandidate {
+                seed_symbol_id: seed.id.0.clone(),
+                path: "lib/zzz_helper.rb".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("ruby:lib/service.rb:method:bounce:4".to_string()),
+                via_path: Some("lib/service.rb".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::RequireRelativeChain),
+                prune_reason: ImpactSlicePruneReason::RankedOut,
+                scoring: Some(test_tier2_scoring(
+                    ImpactSliceCandidateLane::RequireRelativeContinuation,
+                    vec![ImpactSliceEvidenceKind::RequireRelativeEdge],
+                    vec![ImpactSliceEvidenceKind::CallsitePositionHint],
+                    7,
+                    "lib/zzz_helper.rb",
+                )),
+            }],
+            "expected later Ruby helper noise to stay a single ranked-out require_relative fallback: {:#?}",
             plan.slice_selection.pruned_candidates
         );
     }

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1487,6 +1487,34 @@ fn pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_nois
             })),
         "expected later Ruby helper noise to be preserved only as require_relative ranked-out metadata: {prop:#}"
     );
+    let witness = &prop["impacted_witnesses"]["ruby:lib/leaf.rb:method:finish:1"];
+    let leaf_context = witness_slice_file(witness, "lib/leaf.rb");
+    assert_eq!(
+        leaf_context["selected_vs_pruned_reasons"],
+        serde_json::json!([{
+            "via_symbol_id": "ruby:lib/service.rb:method:bounce:4",
+            "via_path": "lib/service.rb",
+            "selected_bridge_kind": "wrapper_return",
+            "pruned_path": "lib/zzz_helper.rb",
+            "prune_reason": "ranked_out",
+            "pruned_bridge_kind": "require_relative_chain",
+            "selected_better_by": "lane",
+            "summary": "selected over lib/zzz_helper.rb because return_continuation outranked require_relative_continuation",
+        }])
+    );
+    let helper_witness =
+        &prop["impacted_witnesses"]["ruby:lib/zzz_helper.rb:method:helper_noise:1"];
+    let helper_paths: Vec<&str> = helper_witness["slice_context"]["selected_files_on_path"]
+        .as_array()
+        .expect("helper witness slice_context.selected_files_on_path array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(
+        helper_paths,
+        vec!["app/runner.rb", "lib/service.rb"],
+        "expected Ruby helper noise to stay outside the bounded explanation slice even if it remains reachable: {prop:#}"
+    );
 
     let prop_dot = run_impact_dot(
         &repo,


### PR DESCRIPTION
## Summary
- tighten the Ruby bounded-slice planner regression by asserting the exact ranked-out require_relative fallback candidate metadata
- extend the Ruby CLI propagation fixture to prove the selected-vs-pruned witness explanation stays attached to the semantic leaf choice
- lock the bounded explanation surface so helper noise remains outside the helper witness slice context even when it is still reachable

## Testing
- cargo test --offline --bin dimpact
- cargo test --offline --test cli_pdg_propagation
- git diff --check