### PR TITLE
docs: explain bridge scoring and scope split

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,14 @@ CLI Overview
   - `provenance_chain` / `kind_chain` make it easier to see where call / data / control / symbolic-propagation edges entered that route
   - `path_compact` / `provenance_chain_compact` / `kind_chain_compact` keep the same route in a more compressed, explanation-oriented form
   - `slice_context.selected_files_on_path` lightly connects that witness route back to the bounded-slice planner, so you can see which selected files were actually on the witness path, which hop indices they covered, and which slice-selection reasons retained them
+  - `slice_context.selected_vs_pruned_reasons` adds the minimal "why this won" explanation when a selected bridge candidate beat a ranked-out competitor
   - this is still one selected shortest-path explanation, not an exhaustive proof of every possible route
 - `summary.slice_selection` is emitted on the PDG / propagation path and exposes the bounded-slice planner decision itself:
   - `files[*]` lists the selected file-level scope with `cache_update` / `local_dfg` / `explanation` split
   - `files[*].reasons[*]` records the selection reason per seed, including direct-boundary vs bridge-completion distinctions
+  - `files[*].reasons[*].scoring` and `pruned_candidates[*].scoring` expose the bridge-candidate score profile (`source_kind`, `lane`, evidence kinds, score tuple), so selected-vs-pruned comparisons are reviewable from JSON/YAML output
   - `pruned_candidates[*]` gives the minimal diagnostics for ranked-out / budget-pruned candidates when the planner had to drop alternatives
+  - read the scope split as: `cache_update` = execution preparation, `local_dfg` = local flow materialization, `explanation` = user-facing retained file; `local_dfg` and `explanation` may diverge, and pruned candidates do not become explanation files
 - With `--per-seed`, the same summary appears under `impacts[].output.summary` for each changed/seed symbol, and witness data stays nested under each grouped output.
 - DOT/HTML output stays compatible; the new summary fields are for JSON/YAML consumption.
 
@@ -214,6 +217,8 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
   - `impact --with-pdg -f dot` shows the raw PDG/DFG-style graph instead
 - Ruby has improved short multi-file coverage, but still has clear boundaries:
   - short `require_relative` / alias / wrapper-return chains are better than before, including no-paren wrapper parameter flow
+  - bridge scoring now tries to keep semantic alias / return-flow completions ahead of plain `require_relative` helper noise, while leaving weaker fallback paths visible as ranked-out candidates instead of silently broadening scope
+  - fallback discovery is still intentionally narrow: the goal is bounded explanation, not broad Ruby companion expansion
   - longer `require_relative` ladders, dynamic-send-heavy flows, and broader companion discovery are still intentionally under-modeled
   - treat Ruby PDG / propagation as a bounded explanation aid, not as a complete inter-procedural proof system
 - Engine integration is improved but still uneven:
@@ -225,6 +230,7 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - Add `--with-pdg` when you want to ask: "which nearby Rust/Ruby files belong in the bounded explanation slice, and what local data/control edges appear there?"
 - Escalate to `--with-propagation` when the interesting question is "does this value/argument/result flow across the call boundary?", especially for short Rust/Ruby multi-file bridges.
 - When the PDG / propagation output looks surprising, inspect `summary.slice_selection` first to see which files were selected or pruned, then inspect `impacted_witnesses[*].slice_context` to connect that file-level reason back to the chosen witness path.
+- If a bridge choice still looks odd, compare `files[*].reasons[*].scoring` against `pruned_candidates[*].scoring`, then check `slice_context.selected_vs_pruned_reasons` for the compact human-facing explanation.
 - If you need to review one seed at a time, add `--per-seed` to any of the above and inspect `impacted_witnesses`, especially the compact witness fields, for the chosen path summary.
 - If you are working in Go/Java/Python/JS/TS/TSX, do not assume `--with-pdg` adds much today; treat it as experimental unless the fixture/regression says otherwise.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -132,11 +132,14 @@ dimpact id --name foo -f json
   - `provenance_chain` / `kind_chain` で、その経路のどこに call / data / control / symbolic_propagation が入ったかを追いやすくなります
   - `path_compact` / `provenance_chain_compact` / `kind_chain_compact` は、その同じ経路をより説明しやすい圧縮形で返します
   - `slice_context.selected_files_on_path` を見ると、その witness 経路上の file が bounded-slice planner でどう選ばれたか、どの hop index を担当したか、どの seed-specific reason で残ったかを軽く追えます
+  - `slice_context.selected_vs_pruned_reasons` には、selected された bridge candidate が ranked-out 候補に勝った最小理由が入ります
   - ただし、これは依然として 1 本の最短経路ベースの説明であり、すべての候補経路を網羅するものではありません
 - `summary.slice_selection` は PDG / propagation path で出力され、bounded-slice planner 自体の判断を見せます:
   - `files[*]` で選ばれた file-level scope と `cache_update` / `local_dfg` / `explanation` の分離を確認できます
   - `files[*].reasons[*]` で direct boundary と bridge completion を含む seed ごとの選定理由を確認できます
+  - `files[*].reasons[*].scoring` と `pruned_candidates[*].scoring` を見ると、`source_kind` / `lane` / evidence kind / score tuple まで含めた bridge candidate の比較根拠を JSON/YAML 上で追えます
   - `pruned_candidates[*]` で ranked-out / budget prune された候補の最小診断を確認できます
+  - scope split は `cache_update` = 実行準備、`local_dfg` = ローカル flow の materialization、`explanation` = user-facing に残す file、という意図です。`local_dfg` と `explanation` は分かれうる一方、pruned candidate は explanation file には昇格しません
 - `--per-seed` 指定時は、各変更/シードシンボルごとの `impacts[].output.summary` 配下に同じ summary が入り、witness も各 grouped output の中にネストされます。
 - DOT/HTML 出力は互換維持で、今回の summary は JSON/YAML 利用を主対象としています。
 
@@ -230,6 +233,8 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
   - `impact --with-pdg -f dot` は raw な PDG/DFG 風グラフです
 - Ruby は short multi-file case が前進した一方で、限界もまだあります
   - `require_relative` / alias / wrapper-return の短い chain や no-paren wrapper parameter flow は以前より拾いやすくなりました
+  - bridge scoring は、semantic に強い alias / return-flow completion を単純な `require_relative` helper noise より優先しつつ、弱い fallback は scope を広げず ranked-out candidate として残す方針です
+  - fallback discovery 自体はまだ意図的に narrow で、広い companion expansion を目指してはいません
   - ただし、長い `require_relative` ladder、dynamic-send が強い flow、広い companion discovery はまだ意図的に弱く抑えています
   - Ruby の PDG / propagation は、完全な inter-procedural proof system ではなく、bounded な explainability aid として見るのが安全です
 - エンジン統合は改善したが、まだ完全ではありません
@@ -241,6 +246,7 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - 「どの近傍 file まで bounded slice に入るのか」と、その中の Rust/Ruby data/control dependency を見たいなら `--with-pdg` を足す
 - 「この値・引数・結果は call 境界を越えて伝播するか？」が本題なら `--with-propagation` まで上げる。特に短い Rust/Ruby の multi-file bridge を見たいときに有効です
 - PDG / propagation の結果が意外だったら、まず `summary.slice_selection` で selected / pruned file を見て、その後に `impacted_witnesses[*].slice_context` で why-this-file と why-this-path の対応を追うのが分かりやすいです
+- bridge choice がまだ不自然に見える場合は、`files[*].reasons[*].scoring` と `pruned_candidates[*].scoring` を見比べ、最後に `slice_context.selected_vs_pruned_reasons` で人間向けの最小説明を確認してください
 - seed ごとに分けて見たいなら、上のどれに対しても `--per-seed` を足し、`impacted_witnesses` と compact witness fields を見る
 - Go/Java/Python/JS/TS/TSX では、現時点の `--with-pdg` に大きな上積みを期待しすぎない方が安全です。fixture / regression で確認できる範囲の experimental 機能として扱ってください
 


### PR DESCRIPTION
## Summary
- document the new bridge scoring fields and selected-vs-pruned witness explanation in README and README_ja
- explain the intent behind the cache/local_dfg/explanation scope split in the bounded slice planner
- clarify that Ruby fallback remains narrow and that semantic alias/return-flow completions should beat plain require_relative helper noise

## Testing
- git diff --check