### PR TITLE
Extend bridge scoring evidence schema

### DIFF
--- a/docs/g8-2-bridge-scoring-evidence-schema.json
+++ b/docs/g8-2-bridge-scoring-evidence-schema.json
@@ -1,0 +1,112 @@
+{
+  "generated_by": "manual G8-2 scoring schema extension note",
+  "repo_root": "/home/shioriko/src/github.com/n01e0/dimpact",
+  "purpose": "backward-compatible public schema extension for bridge scoring evidence kinds and nested support metadata",
+  "extends": [
+    "docs/g7-2-bridge-scoring-schema.md",
+    "docs/g8-1-missing-evidence-inventory-and-design-memo.md"
+  ],
+  "applies_to": [
+    "summary.slice_selection.files[].reasons[].scoring",
+    "summary.slice_selection.pruned_candidates[].scoring"
+  ],
+  "goal": [
+    "add future-facing semantic evidence kinds without changing current runtime ranking behavior",
+    "separate support metadata from evidence kinds",
+    "preserve existing JSON output when support is absent or empty",
+    "provide schema hooks for G8-3 Rust evidence, G8-4 Ruby fallback, and G8-5 witness explanation"
+  ],
+  "non_goals": [
+    "runtime materialization of the new evidence kinds in G8-2",
+    "changing score tuple compare order",
+    "changing existing bridge candidate selection behavior",
+    "implementing witness wording in G8-2"
+  ],
+  "schema_changes": {
+    "impact_slice_candidate_scoring_summary": {
+      "adds": [
+        "support?: ImpactSliceCandidateSupportMetadata"
+      ],
+      "field_order": [
+        "source_kind",
+        "lane",
+        "primary_evidence_kinds",
+        "secondary_evidence_kinds",
+        "score_tuple",
+        "support"
+      ],
+      "support_omitted_when": [
+        "support is null",
+        "support exists but all boolean flags are false and edge_certainty is null"
+      ]
+    },
+    "impact_slice_evidence_kind": {
+      "adds": [
+        "param_to_return_flow",
+        "explicit_require_relative_load",
+        "companion_file_match",
+        "dynamic_dispatch_literal_target"
+      ],
+      "existing_values_retained": [
+        "return_flow",
+        "assigned_result",
+        "alias_chain",
+        "require_relative_edge",
+        "module_companion",
+        "callsite_position_hint",
+        "name_path_hint"
+      ]
+    },
+    "impact_slice_candidate_support_metadata": {
+      "fields": [
+        "call_graph_support?: bool",
+        "local_dfg_support?: bool",
+        "symbolic_propagation_support?: bool",
+        "edge_certainty?: ImpactSliceSupportEdgeCertainty"
+      ]
+    }
+  },
+  "support_metadata": {
+    "field_name": "support",
+    "role": "separate support/provenance/certainty from evidence kinds",
+    "fields": {
+      "call_graph_support": "call graph adjacency materially supported the candidate",
+      "local_dfg_support": "local DFG or def-use continuity materially supported the candidate",
+      "symbolic_propagation_support": "symbolic propagation materially supported the candidate",
+      "edge_certainty": [
+        "confirmed",
+        "inferred",
+        "dynamic_fallback"
+      ]
+    },
+    "design_rule": "support metadata must not replace primary evidence kinds"
+  },
+  "evidence_kind_meaning": {
+    "param_to_return_flow": "parameter-origin value flows through alias/assignment/return to the candidate output",
+    "explicit_require_relative_load": "an explicit require_relative load relation was observed",
+    "companion_file_match": "candidate matched a narrow companion-file rule",
+    "dynamic_dispatch_literal_target": "dynamic dispatch narrowed to a literal method target"
+  },
+  "stability": {
+    "existing_runtime_json_unchanged_when_new_fields_unset": true,
+    "scoring_support_is_optional": true,
+    "empty_support_omitted": true,
+    "selected_and_pruned_share_same_scoring_shape": true,
+    "snake_case_enum_serialization": true
+  },
+  "future_hooks": {
+    "g8_3": [
+      "populate param_to_return_flow for Rust wrapper/bridge cases",
+      "set local_dfg_support when local continuity is actually observed"
+    ],
+    "g8_4": [
+      "materialize explicit_require_relative_load for Ruby require_relative edges",
+      "materialize companion_file_match for true narrow fallback",
+      "materialize dynamic_dispatch_literal_target for literal send/public_send narrowing"
+    ],
+    "g8_5": [
+      "derive winning_primary_evidence from selected-vs-pruned evidence set difference",
+      "derive winning_support from selected-vs-pruned support metadata difference"
+    ]
+  }
+}

--- a/docs/g8-2-bridge-scoring-evidence-schema.md
+++ b/docs/g8-2-bridge-scoring-evidence-schema.md
@@ -1,0 +1,270 @@
+# G8-2: bridge scoring evidence schema extension
+
+対象: bounded slice planner の Tier 2 / Tier 3 scoring schema
+
+このメモは、G7-2 で公開した bridge scoring schema を、
+G8-1 の不足棚卸しに沿って **schema だけ先に拡張**するためのもの。
+
+G8-2 では runtime evidence collection はまだ実装しない。
+やるのは次だけである。
+
+- public Rust type を将来の semantic evidence / support metadata を受けられる shape に広げる
+- docs / machine-readable schema / tests でその契約を固定する
+- 既存 runtime output は、新 field が明示的に埋まらない限り変えない
+
+machine-readable companion: `docs/g8-2-bridge-scoring-evidence-schema.json`
+
+設計 input:
+
+- `docs/g7-2-bridge-scoring-schema.md`
+- `docs/g8-1-missing-evidence-inventory-and-design-memo.md`
+
+---
+
+## 1. Goal / Non-goal
+
+## Goal
+
+- G7-2 の `ImpactSliceCandidateScoringSummary` を後方互換で拡張する
+- semantic continuity / narrow fallback 用の新 evidence kind を public enum に追加する
+- evidence kind と別に、将来の G8-3 / G8-4 / G8-5 が使う support metadata の置き場を作る
+- support が空のときは JSON へ出さず、既存 fixture / runtime output の安定性を保つ
+
+## Non-goal
+
+- G8-2 で `tier2_scoring_summary()` や Ruby fallback runtime を強化すること
+- G8-2 で new evidence を実際に materialize すること
+- witness explanation wording を G8-2 で確定すること
+- score tuple の compare order を変えること
+
+---
+
+## 2. Schema delta
+
+G8-2 の public delta は次である。
+
+```rust
+pub struct ImpactSliceCandidateScoringSummary {
+    pub source_kind: ImpactSliceCandidateSourceKind,
+    pub lane: ImpactSliceCandidateLane,
+    pub primary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
+    pub secondary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
+    pub score_tuple: ImpactSliceScoreTuple,
+    pub support: Option<ImpactSliceCandidateSupportMetadata>,
+}
+
+pub enum ImpactSliceEvidenceKind {
+    ReturnFlow,
+    AssignedResult,
+    AliasChain,
+    ParamToReturnFlow,
+    RequireRelativeEdge,
+    ExplicitRequireRelativeLoad,
+    ModuleCompanion,
+    CompanionFileMatch,
+    DynamicDispatchLiteralTarget,
+    CallsitePositionHint,
+    NamePathHint,
+}
+
+pub struct ImpactSliceCandidateSupportMetadata {
+    pub call_graph_support: bool,
+    pub local_dfg_support: bool,
+    pub symbolic_propagation_support: bool,
+    pub edge_certainty: Option<ImpactSliceSupportEdgeCertainty>,
+}
+
+pub enum ImpactSliceSupportEdgeCertainty {
+    Confirmed,
+    Inferred,
+    DynamicFallback,
+}
+```
+
+`ImpactSliceReasonMetadata.scoring` と `ImpactSlicePrunedCandidate.scoring` の外形は変えない。
+拡張点は `scoring` object の中だけに留める。
+
+---
+
+## 3. New evidence kinds
+
+G8-1 で不足として挙がった最小追加は次の 4 つである。
+
+### `param_to_return_flow`
+
+callee param 由来の値が alias / assignment / return を通って外へ抜ける continuity。
+
+使いどころ:
+
+- Rust short wrapper / passthrough
+- Ruby no-paren wrapper
+- G8-5 witness の winning primary evidence
+
+### `explicit_require_relative_load`
+
+`require_relative` の明示 load 関係が観測できたこと。
+
+使いどころ:
+
+- Ruby graph-first continuation と helper noise の分離
+- G8-4 narrow fallback の bounded rule explanation
+
+### `companion_file_match`
+
+basename / module companion / require-relative companion の narrow rule で candidate を拾えたこと。
+
+使いどころ:
+
+- `lane = module_companion_fallback` の runtime materialization
+- fallback candidate の debug / review
+
+### `dynamic_dispatch_literal_target`
+
+`send(:sym)` / `public_send("name")` のような dynamic dispatch で literal target まで narrowing できたこと。
+
+使いどころ:
+
+- G8-4 dynamic-heavy Ruby fallback
+- G8-5 witness での narrow fallback explanation
+
+---
+
+## 4. Support metadata
+
+G8-1 の原則どおり、
+
+- `evidence_kind` は continuity / fallback selection の事実
+- `support` は provenance / strength / certainty
+
+を別に持つ。
+
+G8-2 では flatten せず、`scoring.support` の 1 object にまとめる。
+
+```json
+{
+  "support": {
+    "call_graph_support": true,
+    "local_dfg_support": true,
+    "symbolic_propagation_support": true,
+    "edge_certainty": "confirmed"
+  }
+}
+```
+
+各 field の意味:
+
+- `call_graph_support`
+  - call graph adjacency が support として使われた
+- `local_dfg_support`
+  - local DFG / def-use continuity が support した
+- `symbolic_propagation_support`
+  - symbolic propagation が support した
+- `edge_certainty`
+  - winner/pruned explanation で certainty を短く表したいときの hook
+
+この support object は **evidence kind の代用品ではない**。
+たとえば `return_flow` と `local_dfg_support` は別物として保持する。
+
+---
+
+## 5. Stability / compatibility rules
+
+既存 runtime JSON の安定性のため、G8-2 では次を固定する。
+
+- `support` は `None` または empty object 相当なら serialize しない
+- 既存 runtime が `support = None` のままなら、`scoring` の既存 field は G7-2 と同じ shape のまま出る
+- `primary_evidence_kinds` / `secondary_evidence_kinds` の意味や compare order は G7-2 のまま
+- new evidence kind は enum に増えるだけで、G8-2 runtime では未使用でもよい
+- field order は既存 `source_kind` / `lane` / `primary_evidence_kinds` / `secondary_evidence_kinds` / `score_tuple` を保ち、`support` は末尾に付く
+
+### Omitted example
+
+```json
+{
+  "source_kind": "graph_second_hop",
+  "lane": "return_continuation",
+  "primary_evidence_kinds": ["return_flow"],
+  "secondary_evidence_kinds": [],
+  "score_tuple": {
+    "source_rank": 0,
+    "lane_rank": 0,
+    "primary_evidence_count": 1,
+    "secondary_evidence_count": 0,
+    "call_position_rank": 3,
+    "lexical_tiebreak": "leaf.rs"
+  }
+}
+```
+
+### Populated example
+
+```json
+{
+  "source_kind": "narrow_fallback",
+  "lane": "module_companion_fallback",
+  "primary_evidence_kinds": [
+    "companion_file_match",
+    "dynamic_dispatch_literal_target",
+    "explicit_require_relative_load",
+    "param_to_return_flow"
+  ],
+  "secondary_evidence_kinds": ["name_path_hint"],
+  "score_tuple": {
+    "source_rank": 1,
+    "lane_rank": 3,
+    "primary_evidence_count": 4,
+    "secondary_evidence_count": 1,
+    "call_position_rank": 0,
+    "lexical_tiebreak": "demo/helper.rb"
+  },
+  "support": {
+    "call_graph_support": true,
+    "local_dfg_support": true,
+    "symbolic_propagation_support": true,
+    "edge_certainty": "dynamic_fallback"
+  }
+}
+```
+
+---
+
+## 6. Task mapping
+
+### G8-2
+
+- enum / struct / serde contract を追加する
+- docs / tests で omit rule を lock する
+
+### G8-3
+
+- Rust runtime で `assigned_result` / `alias_chain` / `param_to_return_flow` を semantic fact 寄りに materialize する
+- 必要なら `support.local_dfg_support` を埋める
+
+### G8-4
+
+- Ruby runtime で `explicit_require_relative_load`
+- `companion_file_match`
+- `dynamic_dispatch_literal_target`
+- `source_kind = narrow_fallback`
+- `lane = module_companion_fallback`
+
+を bounded に materialize する
+
+### G8-5
+
+- selected/pruned diff と witness explanation を `primary_evidence_kinds` + `support` 差分から組み立てる
+
+---
+
+## 7. Conclusion
+
+G8-2 で固定するべきなのは、runtime 実装の先回りではなく、
+**future semantic evidence を載せられる public schema を後方互換で先に作ること** である。
+
+そのための最小差分は、
+
+- new primary evidence kinds 4 個の追加
+- `scoring.support` の nested metadata object 追加
+- empty support omission による backward compatibility の維持
+
+で十分である。

--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1256,6 +1256,7 @@ fn ruby_require_relative_scoring_summary(
             call_position_rank: call_line,
             lexical_tiebreak: completion_file.to_string(),
         },
+        support: None,
     }
 }
 
@@ -1264,8 +1265,12 @@ fn evidence_kind_key(kind: ImpactSliceEvidenceKind) -> &'static str {
         ImpactSliceEvidenceKind::AliasChain => "alias_chain",
         ImpactSliceEvidenceKind::AssignedResult => "assigned_result",
         ImpactSliceEvidenceKind::CallsitePositionHint => "callsite_position_hint",
+        ImpactSliceEvidenceKind::CompanionFileMatch => "companion_file_match",
+        ImpactSliceEvidenceKind::DynamicDispatchLiteralTarget => "dynamic_dispatch_literal_target",
+        ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad => "explicit_require_relative_load",
         ImpactSliceEvidenceKind::ModuleCompanion => "module_companion",
         ImpactSliceEvidenceKind::NamePathHint => "name_path_hint",
+        ImpactSliceEvidenceKind::ParamToReturnFlow => "param_to_return_flow",
         ImpactSliceEvidenceKind::RequireRelativeEdge => "require_relative_edge",
         ImpactSliceEvidenceKind::ReturnFlow => "return_flow",
     }
@@ -1392,6 +1397,7 @@ fn tier2_scoring_summary(
         },
         primary_evidence_kinds,
         secondary_evidence_kinds,
+        support: None,
     }
 }
 
@@ -2900,6 +2906,7 @@ fn caller() -> i32 {
             },
             primary_evidence_kinds,
             secondary_evidence_kinds,
+            support: None,
         }
     }
 
@@ -3552,5 +3559,27 @@ fn caller() -> i32 {
         );
         assert!(matches!(min_c, Some(ConfidenceOpt::DynamicFallback)));
         assert!(excl_c);
+    }
+
+    #[test]
+    fn evidence_kind_key_sorts_new_g8_2_evidence_names_lexically() {
+        let mut kinds = vec![
+            ImpactSliceEvidenceKind::ParamToReturnFlow,
+            ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad,
+            ImpactSliceEvidenceKind::CompanionFileMatch,
+            ImpactSliceEvidenceKind::DynamicDispatchLiteralTarget,
+        ];
+
+        kinds.sort_by_key(|kind| evidence_kind_key(*kind));
+
+        assert_eq!(
+            kinds,
+            vec![
+                ImpactSliceEvidenceKind::CompanionFileMatch,
+                ImpactSliceEvidenceKind::DynamicDispatchLiteralTarget,
+                ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad,
+                ImpactSliceEvidenceKind::ParamToReturnFlow,
+            ]
+        );
     }
 }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -130,6 +130,11 @@ pub struct ImpactSliceCandidateScoringSummary {
     pub primary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
     pub secondary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
     pub score_tuple: ImpactSliceScoreTuple,
+    #[serde(
+        default,
+        skip_serializing_if = "impact_slice_candidate_support_is_absent"
+    )]
+    pub support: Option<ImpactSliceCandidateSupportMetadata>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -154,10 +159,56 @@ pub enum ImpactSliceEvidenceKind {
     ReturnFlow,
     AssignedResult,
     AliasChain,
+    ParamToReturnFlow,
     RequireRelativeEdge,
+    ExplicitRequireRelativeLoad,
     ModuleCompanion,
+    CompanionFileMatch,
+    DynamicDispatchLiteralTarget,
     CallsitePositionHint,
     NamePathHint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ImpactSliceCandidateSupportMetadata {
+    #[serde(default, skip_serializing_if = "impact_slice_bool_is_false")]
+    pub call_graph_support: bool,
+    #[serde(default, skip_serializing_if = "impact_slice_bool_is_false")]
+    pub local_dfg_support: bool,
+    #[serde(default, skip_serializing_if = "impact_slice_bool_is_false")]
+    pub symbolic_propagation_support: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edge_certainty: Option<ImpactSliceSupportEdgeCertainty>,
+}
+
+impl ImpactSliceCandidateSupportMetadata {
+    fn is_empty(&self) -> bool {
+        !self.call_graph_support
+            && !self.local_dfg_support
+            && !self.symbolic_propagation_support
+            && self.edge_certainty.is_none()
+    }
+}
+
+fn impact_slice_bool_is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn impact_slice_candidate_support_is_absent(
+    support: &Option<ImpactSliceCandidateSupportMetadata>,
+) -> bool {
+    match support {
+        None => true,
+        Some(support) => support.is_empty(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactSliceSupportEdgeCertainty {
+    Confirmed,
+    Inferred,
+    DynamicFallback,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -2520,6 +2571,7 @@ fn foo() { bar(); }
                     call_position_rank: 8,
                     lexical_tiebreak: "leaf.rs".to_string(),
                 },
+                support: None,
             }),
         };
         let slice_selection = ImpactSliceSelectionSummary {
@@ -2591,6 +2643,7 @@ fn foo() { bar(); }
                         call_position_rank: 7,
                         lexical_tiebreak: "aaa_helper.rs".to_string(),
                     },
+                    support: None,
                 }),
             }],
         };
@@ -3086,5 +3139,97 @@ fn foo() { bar(); }
         assert_eq!(risk.level, ImpactRiskLevel::High);
         assert_eq!(risk.direct_hits, 2);
         assert_eq!(risk.transitive_hits, 2);
+    }
+
+    #[test]
+    fn scoring_summary_omits_empty_support_metadata_from_json() {
+        let scoring = ImpactSliceCandidateScoringSummary {
+            source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+            lane: ImpactSliceCandidateLane::ReturnContinuation,
+            primary_evidence_kinds: vec![ImpactSliceEvidenceKind::ReturnFlow],
+            secondary_evidence_kinds: vec![],
+            score_tuple: ImpactSliceScoreTuple {
+                source_rank: 0,
+                lane_rank: 0,
+                primary_evidence_count: 1,
+                secondary_evidence_count: 0,
+                call_position_rank: 3,
+                lexical_tiebreak: "leaf.rs".to_string(),
+            },
+            support: Some(ImpactSliceCandidateSupportMetadata::default()),
+        };
+
+        let value = serde_json::to_value(&scoring).expect("serialize scoring summary");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "source_kind": "graph_second_hop",
+                "lane": "return_continuation",
+                "primary_evidence_kinds": ["return_flow"],
+                "secondary_evidence_kinds": [],
+                "score_tuple": {
+                    "source_rank": 0,
+                    "lane_rank": 0,
+                    "primary_evidence_count": 1,
+                    "secondary_evidence_count": 0,
+                    "call_position_rank": 3,
+                    "lexical_tiebreak": "leaf.rs"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn scoring_summary_round_trips_new_evidence_kinds_and_support_metadata() {
+        let scoring = ImpactSliceCandidateScoringSummary {
+            source_kind: ImpactSliceCandidateSourceKind::NarrowFallback,
+            lane: ImpactSliceCandidateLane::ModuleCompanionFallback,
+            primary_evidence_kinds: vec![
+                ImpactSliceEvidenceKind::CompanionFileMatch,
+                ImpactSliceEvidenceKind::DynamicDispatchLiteralTarget,
+                ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad,
+                ImpactSliceEvidenceKind::ParamToReturnFlow,
+            ],
+            secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+            score_tuple: ImpactSliceScoreTuple {
+                source_rank: 1,
+                lane_rank: 3,
+                primary_evidence_count: 4,
+                secondary_evidence_count: 1,
+                call_position_rank: 0,
+                lexical_tiebreak: "demo/helper.rb".to_string(),
+            },
+            support: Some(ImpactSliceCandidateSupportMetadata {
+                call_graph_support: true,
+                local_dfg_support: true,
+                symbolic_propagation_support: true,
+                edge_certainty: Some(ImpactSliceSupportEdgeCertainty::DynamicFallback),
+            }),
+        };
+
+        let value = serde_json::to_value(&scoring).expect("serialize scoring summary");
+        assert_eq!(
+            value["primary_evidence_kinds"],
+            serde_json::json!([
+                "companion_file_match",
+                "dynamic_dispatch_literal_target",
+                "explicit_require_relative_load",
+                "param_to_return_flow"
+            ])
+        );
+        assert_eq!(
+            value["support"],
+            serde_json::json!({
+                "call_graph_support": true,
+                "local_dfg_support": true,
+                "symbolic_propagation_support": true,
+                "edge_certainty": "dynamic_fallback"
+            })
+        );
+
+        let round_tripped: ImpactSliceCandidateScoringSummary =
+            serde_json::from_value(value).expect("deserialize scoring summary");
+        assert_eq!(round_tripped, scoring);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,12 @@ pub use engine::{AnalysisEngine, EngineKind};
 pub use impact::{
     ImpactAffectedModule, ImpactDepthBucket, ImpactDirection, ImpactOptions, ImpactOutput,
     ImpactRiskLevel, ImpactRiskSummary, ImpactSliceBridgeKind, ImpactSliceCandidateLane,
-    ImpactSliceCandidateScoringSummary, ImpactSliceCandidateSourceKind, ImpactSliceEvidenceKind,
-    ImpactSliceFileMetadata, ImpactSlicePlannerKind, ImpactSlicePruneReason,
-    ImpactSlicePrunedCandidate, ImpactSliceReasonKind, ImpactSliceReasonMetadata,
-    ImpactSliceScopes, ImpactSliceScoreTuple, ImpactSliceSelectionSummary, ImpactSummary,
-    ImpactWitness, ImpactWitnessHop, ImpactWitnessSliceContext, ImpactWitnessSliceFileContext,
+    ImpactSliceCandidateScoringSummary, ImpactSliceCandidateSourceKind,
+    ImpactSliceCandidateSupportMetadata, ImpactSliceEvidenceKind, ImpactSliceFileMetadata,
+    ImpactSlicePlannerKind, ImpactSlicePruneReason, ImpactSlicePrunedCandidate,
+    ImpactSliceReasonKind, ImpactSliceReasonMetadata, ImpactSliceScopes, ImpactSliceScoreTuple,
+    ImpactSliceSelectionSummary, ImpactSliceSupportEdgeCertainty, ImpactSummary, ImpactWitness,
+    ImpactWitnessHop, ImpactWitnessSliceContext, ImpactWitnessSliceFileContext,
     ImpactWitnessSliceRankingBasis, ImpactWitnessSliceSelectedVsPrunedReason,
     attach_slice_selection_summary, build_project_graph, compute_impact, path_is_ignored,
 };


### PR DESCRIPTION
## Summary
- extend the public bridge scoring schema with new evidence kinds for future G8 work
- add nested support metadata that is omitted from JSON when empty to keep current runtime output stable
- document the G8-2 contract in markdown + machine-readable JSON and cover it with serde/tests

## Testing
- cargo test --offline
- cargo clippy --offline