### PR TITLE
Document evidence-driven selection in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ CLI Overview
 - With `--per-seed`, the same summary appears under `impacts[].output.summary` for each changed/seed symbol, and witness data stays nested under each grouped output.
 - DOT/HTML output stays compatible; the new summary fields are for JSON/YAML consumption.
 
+### Evidence-driven selection: how to think about it
+- The PDG / propagation planner is intentionally **not** trying to include every reachable helper file.
+  - the goal is to keep a small bounded explanation slice and choose the strongest local continuation for each boundary side
+- In practice, bridge / fallback selection is evidence-driven in four layers:
+  1. `source_kind`: prefer graph-backed continuations first; use narrow fallback when the bounded runtime companion evidence is strong enough
+  2. `lane`: prefer semantically stronger continuations such as `return_continuation` / `alias_continuation` over weaker helper-style continuations when both are available
+  3. `primary_evidence_kinds` / `secondary_evidence_kinds`: compare the concrete observed facts, such as `param_to_return_flow`, `return_flow`, `explicit_require_relative_load`, `companion_file_match`, or `dynamic_dispatch_literal_target`
+  4. `support`: use flags like `local_dfg_support`, `symbolic_propagation_support`, and `edge_certainty` to explain why a selected candidate was trustworthy
+- The important operational idea is: **better evidence should improve precision without widening scope**.
+  - a stronger winner becomes the selected explanation file
+  - weaker alternatives stay visible in `pruned_candidates[*]` or `slice_context.selected_vs_pruned_reasons` instead of silently expanding the slice
+- A good reading order for surprising Rust/Ruby PDG output is:
+  1. inspect `summary.slice_selection.files[*].reasons[*].scoring`
+  2. compare against `summary.slice_selection.pruned_candidates[*].scoring`
+  3. finish with `impacted_witnesses[*].slice_context.selected_vs_pruned_reasons` for the shortest human-facing explanation
+
 - Impact Options (subcommand `impact`):
   - `--direction callers|callees|both` : traversal direction (default: callers)
   - `--max-depth N`             : max traversal depth (default: 100)

--- a/README_ja.md
+++ b/README_ja.md
@@ -143,6 +143,22 @@ dimpact id --name foo -f json
 - `--per-seed` 指定時は、各変更/シードシンボルごとの `impacts[].output.summary` 配下に同じ summary が入り、witness も各 grouped output の中にネストされます。
 - DOT/HTML 出力は互換維持で、今回の summary は JSON/YAML 利用を主対象としています。
 
+### evidence-driven selection の見方
+- PDG / propagation planner は、到達可能な helper file を全部 scope に入れることを目指していません。
+  - 目的は bounded な explanation slice を保ったまま、boundary side ごとに最も筋の良い continuation を選ぶことです
+- 実際の bridge / fallback 選択は、だいたい次の 4 層で見ると分かりやすいです:
+  1. `source_kind`: まず graph-backed な continuation を優先し、bounded な runtime companion evidence が十分強いときだけ narrow fallback を使う
+  2. `lane`: 両方候補があるなら、`return_continuation` / `alias_continuation` のような semantic に強い continuation を、弱い helper continuation より優先する
+  3. `primary_evidence_kinds` / `secondary_evidence_kinds`: `param_to_return_flow` / `return_flow` / `explicit_require_relative_load` / `companion_file_match` / `dynamic_dispatch_literal_target` のような観測 fact を比べる
+  4. `support`: `local_dfg_support` / `symbolic_propagation_support` / `edge_certainty` などで、その勝ち筋がどれくらい信頼できるかを補足する
+- 運用上の大事な考え方は、**良い evidence は scope を広げずに precision を上げるべき**、という点です。
+  - 強い候補だけが selected explanation file になる
+  - 弱い候補は `pruned_candidates[*]` や `slice_context.selected_vs_pruned_reasons` に残して、黙って slice を広げない
+- Rust/Ruby の PDG 出力が意外だったときは、次の順で読むと追いやすいです:
+  1. `summary.slice_selection.files[*].reasons[*].scoring` を見る
+  2. `summary.slice_selection.pruned_candidates[*].scoring` と見比べる
+  3. 最後に `impacted_witnesses[*].slice_context.selected_vs_pruned_reasons` で人間向けの最短説明を確認する
+
 ### Impact オプション（`impact` サブコマンド）
 - `--direction callers|callees|both` : 方向 (既定: callers)
 - `--max-depth N`               : 最大探索深度 (既定: 100)


### PR DESCRIPTION
## Summary
- add an English README note that explains evidence-driven selection as a bounded-slice scoring model, not a broad helper expansion model
- add the same explanation to README_ja, including how to read selected vs pruned scoring and witness explanations
- keep the docs focused on operational reading order for `summary.slice_selection` and `impacted_witnesses[*].slice_context`

## Validation
- git diff --check
