### PR TITLE
docs: define G9 evidence normalization rules

### DIFF
--- a/docs/g9-2-evidence-normalization-rules.json
+++ b/docs/g9-2-evidence-normalization-rules.json
@@ -1,0 +1,183 @@
+{
+  "generated_by": "manual G9-2 evidence normalization note",
+  "repo_root": "/home/shioriko/src/github.com/n01e0/dimpact",
+  "purpose": "define normalized evidence categories shared by planner, fallback runtime, and witness explanation",
+  "extends": [
+    "docs/g8-2-bridge-scoring-evidence-schema.md",
+    "docs/g9-1-g8-evidence-usage-inventory-and-gap-memo.md"
+  ],
+  "categories": {
+    "primary": {
+      "role": "direct continuity or semantic fact that explains why a candidate should win in its lane",
+      "rules": [
+        "must be candidate-local and directly observed",
+        "must not be created from lexical naming/path hint alone",
+        "can be shared across planner and witness without changing meaning",
+        "must stay separate from fallback admission reasons"
+      ],
+      "examples": [
+        "param_to_return_flow",
+        "observed_return_passthrough",
+        "observed_result_assignment_continuity",
+        "observed_local_alias_flow"
+      ]
+    },
+    "support": {
+      "role": "strength, provenance, certainty, or tie-break signal that strengthens a candidate without justifying it alone",
+      "rules": [
+        "must not replace primary evidence",
+        "may be shared or diffed in witness output",
+        "may include weak positive structural hints",
+        "must remain positive reinforcement, not suppression"
+      ],
+      "examples": [
+        "call_graph_support",
+        "local_dfg_support",
+        "symbolic_propagation_support",
+        "edge_certainty",
+        "callsite_position_hint"
+      ]
+    },
+    "fallback": {
+      "role": "bounded admission provenance for candidates that are not justified by graph-first continuity alone",
+      "rules": [
+        "explains why a fallback candidate is allowed to exist",
+        "must not be treated as primary continuity by default",
+        "must remain visible in witness output for winning and losing fallback choices",
+        "may coexist with primary evidence when fallback candidates later gain semantic continuity"
+      ],
+      "examples": [
+        "explicit_require_relative_load",
+        "companion_file_match",
+        "dynamic_dispatch_literal_target",
+        "require_relative_edge"
+      ]
+    },
+    "negative": {
+      "role": "suppressing or demoting signal used to cap promotion, explain ranked-out losers, or keep noise out of primary/support",
+      "rules": [
+        "must be represented explicitly rather than implied only by absence",
+        "must stay separate from positive categories",
+        "may drive suppress-gates or late compare penalties",
+        "must be renderable as a losing-side reason in witness output"
+      ],
+      "examples": [
+        "helper_noise_hint",
+        "fallback_only_without_semantic_continuity",
+        "late_call_only_without_continuity",
+        "weaker_certainty_than_competitor"
+      ]
+    }
+  },
+  "non_evidence_dimensions": {
+    "source_kind": "candidate collection route, not evidence",
+    "lane": "continuity/completion family, not evidence"
+  },
+  "normalization_rules": [
+    "lexical proxy must not populate primary directly",
+    "graph-first candidates are justified mainly by primary plus support",
+    "fallback candidates must carry fallback provenance when they are materialized",
+    "negative evidence must be preserved so witness can explain losing-side reasons",
+    "shared evidence may be omitted from compact summaries but must remain available to comparison logic"
+  ],
+  "conceptual_compare_order": [
+    "source_kind",
+    "lane",
+    "primary",
+    "support",
+    "fallback",
+    "negative",
+    "deterministic_lexical_tiebreak"
+  ],
+  "g8_mapping": {
+    "keep_as_primary": [
+      "param_to_return_flow"
+    ],
+    "split": {
+      "return_flow": {
+        "primary": [
+          "observed_return_passthrough"
+        ],
+        "support_or_negative": [
+          "return-ish naming/path hint"
+        ]
+      },
+      "assigned_result": {
+        "primary": [
+          "observed_result_assignment_continuity"
+        ],
+        "support": [
+          "wrapper-ish naming/path proxy"
+        ]
+      },
+      "alias_chain": {
+        "primary": [
+          "observed_local_alias_flow"
+        ],
+        "support": [
+          "alias/value/result naming hint"
+        ]
+      },
+      "name_path_hint": {
+        "support": [
+          "weak_positive_structural_hint"
+        ],
+        "negative": [
+          "helper_noise_debug_tmp_suppressor"
+        ]
+      }
+    },
+    "move_to_fallback": [
+      "require_relative_edge",
+      "explicit_require_relative_load",
+      "companion_file_match",
+      "dynamic_dispatch_literal_target"
+    ],
+    "keep_as_support": [
+      "call_graph_support",
+      "local_dfg_support",
+      "symbolic_propagation_support",
+      "edge_certainty",
+      "callsite_position_hint"
+    ],
+    "compat_alias": {
+      "module_companion": "fallback.companion_file_match"
+    }
+  },
+  "cross_surface_contract": {
+    "planner": [
+      "must not inflate primary counts with lexical proxy only",
+      "must keep negative evidence separate from support",
+      "must preserve fallback provenance for fallback candidates"
+    ],
+    "fallback_runtime": [
+      "collect raw observations first",
+      "map observations into fallback/support and optionally primary",
+      "do not bypass normalized categories when materializing narrow fallback candidates"
+    ],
+    "witness": [
+      "must be able to emit winning_primary",
+      "must be able to emit winning_support",
+      "must be able to emit winning_fallback",
+      "must be able to emit losing_negative"
+    ]
+  },
+  "follow_up_tasks": {
+    "g9_3": [
+      "add negative or suppressing evidence to planner scoring",
+      "stop counting helper/noise lexical proxy as positive primary evidence"
+    ],
+    "g9_4": [
+      "reclassify Rust return_flow, assigned_result, and alias_chain toward observed facts",
+      "split lexical proxy into support or negative"
+    ],
+    "g9_5": [
+      "normalize weak Ruby require-relative continuation and true narrow fallback into the same table",
+      "treat require_relative_edge as fallback provenance"
+    ],
+    "g9_6": [
+      "add winning_fallback and losing_negative witness surfaces",
+      "ensure ModuleCompanionFile competitions participate in selected-vs-pruned explanation"
+    ]
+  }
+}

--- a/docs/g9-2-evidence-normalization-rules.md
+++ b/docs/g9-2-evidence-normalization-rules.md
@@ -1,0 +1,450 @@
+# G9-2: evidence normalization rules (`primary / support / fallback / negative`)
+
+対象: bounded slice planner / Ruby narrow fallback / witness explanation
+
+このメモは、G9-1 で整理した
+
+- planner は lexical proxy と semantic fact が混ざっている
+- fallback はより factual だが planner と同じ vocabulary で比較されていない
+- witness は winning-side の差分だけを抜いていて、losing-side や suppressing signal をほぼ持っていない
+
+というズレに対して、
+**G9 以降で evidence をどの category で扱うか** を先に固定するためのもの。
+
+machine-readable companion: `docs/g9-2-evidence-normalization-rules.json`
+
+design input:
+
+- `docs/g8-2-bridge-scoring-evidence-schema.md`
+- `docs/g9-1-g8-evidence-usage-inventory-and-gap-memo.md`
+
+---
+
+## 1. Goal / Non-goal
+
+## Goal
+
+- evidence を `primary / support / fallback / negative` の 4 category に正規化する
+- planner / fallback / witness が同じ category vocabulary を共有できるようにする
+- 既存 G8 evidence kind を「そのまま残すもの」「split するもの」「compat alias に落とすもの」に分ける
+- G9-3 以降の scoring 実装と G9-6 の witness explanation が、同じ normalized contract を参照できるようにする
+
+## Non-goal
+
+- G9-2 で runtime compare 関数を実装変更すること
+- G9-2 で enum を直ちに増減すること
+- G9-2 で full proof trace や multi-path witness を設計すること
+- lexical hint を完全廃止すること
+
+---
+
+## 2. 正規化の基本原則
+
+## 2.1 `source_kind` / `lane` は evidence ではない
+
+G8 では `source_kind` と `lane` が実質的に evidence の一部のように読める場面があったが、
+G9 ではまずこれを切り分ける。
+
+- `source_kind`
+  - candidate が **どの収集経路** から来たか
+- `lane`
+  - candidate が **どの continuity / completion family** を閉じようとしているか
+- `evidence`
+  - candidate を選ぶ/落とすための根拠
+
+したがって、`graph_second_hop` や `narrow_fallback` は ranking dimension ではあるが、
+`primary / support / fallback / negative` の 4 category には入れない。
+
+## 2.2 evidence は「観測 fact」と「選択上の役割」で分類する
+
+同じ runtime 事実でも、G9 では次の観点で置き場を決める。
+
+1. その fact は **candidate continuity を直接示すか**
+2. その fact は **strength / certainty / tie-break** を補強するだけか
+3. その fact は **fallback candidate を bounded に許可する理由** か
+4. その fact は **候補を suppress / demote / losing-side 化する理由** か
+
+この役割の違いを明示しない限り、planner / fallback / witness は同じ単語を使っても同じ意味にならない。
+
+## 2.3 lexical proxy は primary へ直接入れない
+
+G9 で最も重要な rule はこれである。
+
+- 名前や path 由来の hint だけで `primary` を立てない
+- lexical hint は `support` または `negative` に落とす
+- primary はあくまで「continuity / selection を直接観測した fact」に寄せる
+
+これにより、G8 の
+
+- `return_flow`
+- `assigned_result`
+- `alias_chain`
+
+が name/path proxy で立っていた部分を、正規化後は別 category へ分離できる。
+
+---
+
+## 3. 4 category の定義
+
+## 3.1 Primary
+
+### 定義
+
+`primary` は、candidate がその lane で選ばれるべきことを直接示す **continuity fact / semantic fact** である。
+
+### ルール
+
+- candidate-local に観測できること
+- ranking/witness の両方で同じ意味で読めること
+- lexical naming だけでは立たないこと
+- fallback candidate の admission reason とは分けること
+- shared でも losing-side でも意味が変わらないこと
+
+### G9 での canonical 役割
+
+- planner では最も重要な正の signal
+- witness では `winning_primary_evidence` / `losing_primary_evidence` の基礎になる
+- fallback candidate であっても continuity fact が観測できるなら primary へ載せてよい
+
+### 典型例
+
+- `param_to_return_flow`
+- 実観測された `return_passthrough`
+- 実観測された `result_assignment_continuity`
+- 実観測された `local_alias_flow`
+
+## 3.2 Support
+
+### 定義
+
+`support` は、primary や candidate の信頼度を補強するが、**それだけで candidate を正当化しない** strength/provenance/tie-break signal である。
+
+### ルール
+
+- 単独では candidate admission の理由にならない
+- 単独では `primary` を代替しない
+- shared/diff の両方で witness に出せること
+- provenance / certainty / positional strength / weak structural hint をここへ置く
+
+### G9 での canonical 役割
+
+- planner では primary の次に比較される補強 signal
+- witness では `winning_support` / `losing_support` の基礎になる
+- negative とは別に「正の補強」であることを保つ
+
+### 典型例
+
+- `call_graph_support`
+- `local_dfg_support`
+- `symbolic_propagation_support`
+- `edge_certainty`
+- `callsite_position_hint`
+- positive 側の弱い structural/name hint
+
+## 3.3 Fallback
+
+### 定義
+
+`fallback` は、graph-first では拾えない candidate を **bounded に出現させてよい理由** を表す category である。
+
+### ルール
+
+- continuity fact そのものではなく、fallback admission provenance に寄せる
+- graph-first candidate と narrow fallback candidate を比較するときも、まず「なぜこの fallback candidate が存在してよいか」を説明する用途に使う
+- fallback のみで strong primary を置き換えない
+- fallback candidate の witness では、winning/losing 両方の bounded rule を短く読めるようにする
+
+### G9 での canonical 役割
+
+- planner では fallback lane の candidate admission reason
+- fallback runtime では raw observation を normalized fallback facts に変換する場所
+- witness では `winning_fallback` / `losing_fallback` の素材になる
+
+### 典型例
+
+- `explicit_require_relative_load`
+- `companion_file_match`
+- `dynamic_dispatch_literal_target`
+- weak Ruby continuation 側の `require_relative_edge`
+
+## 3.4 Negative
+
+### 定義
+
+`negative` は、candidate を suppress / demote / fallback-only に留める **負の signal / 抑制 signal** である。
+
+### ルール
+
+- ただ「fact が無い」ことではなく、実際に比較や説明へ使う明示 signal にする
+- positive evidence を上書きせず、別 category として持つ
+- planner では suppress / rank demotion / promotion cap に使う
+- witness では losing-side 理由の短い説明に使う
+
+### G9 での canonical 役割
+
+- helper/noise を primary/support から切り離す
+- dynamic fallback が stronger certainty に負けた理由を説明できるようにする
+- fallback candidate が出現はしたが selected されなかった理由を表す
+
+### 典型例
+
+- helper/noise/debug/tmp 系 name/path hint
+- fallback-only で semantic continuity が無いことを示す suppressing flag
+- weaker `edge_certainty`（差分としては support 側に出るが、比較ロジック上は negative にも変換できる）
+- late-call-only で他の continuity が無い候補
+
+---
+
+## 4. 正規化ルール
+
+## 4.1 candidate admission rule
+
+candidate を出現させる条件は次で正規化する。
+
+### graph-first candidate
+
+- source は graph から来る
+- 選択の正当化は `primary` と `support` で行う
+- weak structural continuation (`require_relative_edge` など) は `fallback` 相当として保持してよいが、primary へは入れない
+
+### narrow fallback candidate
+
+- candidate の存在理由は `fallback` に必ず残す
+- fallback だけで selected されることは許すが、その場合も witness で「fallback admission に依存した勝ち/負け」を読める必要がある
+- fallback candidate に semantic continuity fact が取れた場合だけ、それを `primary` へ追加する
+
+## 4.2 ranking rule
+
+正規化後の比較は conceptually 次の順をとる。
+
+1. `source_kind`
+2. `lane`
+3. `primary`
+4. `support`
+5. `fallback`
+6. `negative`
+7. deterministic lexical tiebreak
+
+ここで重要なのは、`negative` を「最後の雑な補正」にしないこと。
+G9-3 の実装では、次のどちらかで扱う。
+
+- candidate promotion 前の suppress gate
+- compare の終盤で negative profile を比較する rule
+
+どちらを選んでも、**negative を独立 category として保持する** ことが G9-2 の契約である。
+
+## 4.3 witness rendering rule
+
+witness は正規化後、少なくとも次を surface として持てるようにする。
+
+- winning primary
+- winning support
+- winning fallback
+- losing negative
+
+G8 では winning-side の差分だけだったが、G9-2 では losing-side の簡易理由を category として先に定義する。
+
+## 4.4 shared evidence rule
+
+shared evidence は witness で常に全文出す必要はないが、internal comparison では保持してよい。
+ただし summary を作るときは
+
+- winning difference
+- losing suppressor
+- fallback-only admission
+
+を優先し、shared evidence は省略可能とする。
+
+---
+
+## 5. G8 inventory の category mapping
+
+## 5.1 そのまま primary に残すもの
+
+- `param_to_return_flow`
+
+これは G8 時点でも local DFG / function summary 由来の fact なので、そのまま primary に残してよい。
+
+## 5.2 split して扱うもの
+
+### `return_flow`
+
+G8 では lexical proxy を多く含むため、そのまま primary へ残さない。
+正規化後は次に split する。
+
+- observed return continuity -> `primary`
+- return-ish naming/path hint -> `support` または `negative`
+
+### `assigned_result`
+
+G8 では wrapper/path hint と混ざっているため split が必要。
+
+- observed result assignment continuity -> `primary`
+- wrapper-ish naming/path proxy -> `support`
+
+### `alias_chain`
+
+G8 では alias-ish naming で立つことがあるため split が必要。
+
+- observed local alias continuity -> `primary`
+- alias/value/result naming hint -> `support`
+
+### `name_path_hint`
+
+G9 では 1 個の positive hint として持たない。
+少なくとも次へ split する。
+
+- weak positive structural hint -> `support`
+- helper/noise/debug/tmp suppressor -> `negative`
+
+## 5.3 fallback に移すもの
+
+- `require_relative_edge`
+- `explicit_require_relative_load`
+- `companion_file_match`
+- `dynamic_dispatch_literal_target`
+
+特に `require_relative_edge` は G8 では graph-second-hop 側の primary に入っているが、
+正規化後は **continuity fact というより fallback/structural provenance** として扱う。
+
+## 5.4 support に残すもの
+
+- `call_graph_support`
+- `local_dfg_support`
+- `symbolic_propagation_support`
+- `edge_certainty`
+- `callsite_position_hint`
+
+`callsite_position_hint` は G8 でも primary ではなく secondary だったので、
+G9 では support として明示的に扱うのが自然である。
+
+## 5.5 compat alias または廃止候補
+
+### `module_companion`
+
+G8 runtime では実質未使用で、役割も `companion_file_match` と重なっている。
+したがって G9 では次のどちらかに寄せる。
+
+- compat alias として残し、normalized surface では `fallback.companion_file_match` に畳む
+- runtime で未使用なら将来的に削る
+
+G9-2 の時点では **compat alias 扱い** とするのが安全である。
+
+---
+
+## 6. cross-surface contract
+
+## 6.1 Planner contract
+
+planner は normalized された category を少なくとも内部的に分けて扱う。
+
+- `primary`
+  - continuity を示す main signal
+- `support`
+  - provenance / certainty / tie-break 補強
+- `fallback`
+  - candidate admission provenance
+- `negative`
+  - suppress / demote / losing-side signal
+
+少なくとも G9-3 以降、planner は lexical proxy だけで primary count を水増ししてはいけない。
+
+## 6.2 Fallback runtime contract
+
+fallback runtime は raw observation をそのまま planner scoring に流さず、
+次の 2 段を踏む。
+
+1. boundary/candidate observation を集める
+2. それを normalized `fallback` / `support` / 必要なら `primary` に写像する
+
+これにより Ruby narrow fallback と weak require-relative continuation の vocabulary を揃えられる。
+
+## 6.3 Witness contract
+
+witness は selected/pruned comparison から、最低限次を生成できる必要がある。
+
+- winning primary
+- winning support
+- winning fallback
+- losing negative
+
+この contract が入ることで、G9-6 の「losing-side の簡易理由」が無理なく置ける。
+
+---
+
+## 7. 正規化後の最小 example
+
+### graph-first Rust winner
+
+```json
+{
+  "source_kind": "graph_second_hop",
+  "lane": "return_continuation",
+  "primary": ["param_to_return_flow"],
+  "support": ["local_dfg_support", "callsite_position_hint"],
+  "fallback": [],
+  "negative": []
+}
+```
+
+### narrow fallback Ruby candidate
+
+```json
+{
+  "source_kind": "narrow_fallback",
+  "lane": "module_companion_fallback",
+  "primary": [],
+  "support": ["edge_certainty=dynamic_fallback"],
+  "fallback": [
+    "explicit_require_relative_load",
+    "companion_file_match",
+    "dynamic_dispatch_literal_target"
+  ],
+  "negative": ["fallback_only_without_semantic_continuity"]
+}
+```
+
+この shape なら witness は次のように短く言える。
+
+- selected over `helper.rb` because winning fallback: `explicit_require_relative_load + companion_file_match`; losing negative: `fallback_only_without_semantic_continuity`
+
+---
+
+## 8. G9 task mapping
+
+## G9-3
+
+- `negative` / suppressing evidence を planner scoring に入れる
+- helper/noise 系 hint を positive count から外す
+
+## G9-4
+
+- Rust 側の `return_flow` / `assigned_result` / `alias_chain` を observed fact 寄りに再分類する
+- lexical proxy を support/negative へ分ける
+
+## G9-5
+
+- Ruby weak continuation と true narrow fallback を同じ normalized table で扱えるようにする
+- `require_relative_edge` を fallback 側へ寄せる
+
+## G9-6
+
+- witness に `winning_fallback` と `losing_negative` を追加する
+- runtime の `ModuleCompanionFile` 競合も selected/pruned explanation に乗せる
+
+---
+
+## 9. Conclusion
+
+G8 までで evidence vocabulary は増えたが、surface ごとの意味密度はまだ揃っていない。
+G9-2 の正規化 rule は次の一点に尽きる。
+
+**primary は continuity fact、support は strength/provenance、fallback は bounded admission reason、negative は suppress/demotion reasonとして分ける。**
+
+この分離が入ると、
+
+- planner は lexical proxy を primary から外せる
+- fallback は graph-first と同じ comparison story に載せられる
+- witness は winning-side だけでなく losing-side も同じ vocabulary で説明できる
+
+以後の G9 runtime 変更は、この contract を壊さない範囲で行うべきである。


### PR DESCRIPTION
## Summary
- add a G9-2 design memo that defines normalized evidence categories for planner, fallback runtime, and witness explanation
- add a machine-readable companion that maps the current G8 evidence inventory into primary, support, fallback, and negative buckets
- spell out the cross-surface contract for future G9 scoring and witness work

## Testing
- git diff --check
- python3 -m json.tool docs/g9-2-evidence-normalization-rules.json >/dev/null