### PR TITLE
planner: penalize noisy return helper candidates

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -17,8 +17,8 @@ use dimpact::{
     ImpactDirection, ImpactOptions, ImpactOutput, ImpactSliceBridgeKind, ImpactSliceCandidateLane,
     ImpactSliceCandidateScoringSummary, ImpactSliceCandidateSourceKind,
     ImpactSliceCandidateSupportMetadata, ImpactSliceEvidenceKind, ImpactSliceFileMetadata,
-    ImpactSlicePlannerKind, ImpactSlicePruneReason, ImpactSliceReasonKind,
-    ImpactSliceReasonMetadata, ImpactSliceScopes, ImpactSliceScoreTuple,
+    ImpactSliceNegativeEvidenceKind, ImpactSlicePlannerKind, ImpactSlicePruneReason,
+    ImpactSliceReasonKind, ImpactSliceReasonMetadata, ImpactSliceScopes, ImpactSliceScoreTuple,
     ImpactSliceSelectionSummary,
 };
 use env_logger::Env;
@@ -1262,11 +1262,13 @@ fn ruby_narrow_fallback_scoring_summary(
             lane_rank: tier2_lane_rank(ImpactSliceCandidateLane::ModuleCompanionFallback),
             primary_evidence_count: u8::try_from(primary_evidence_kinds.len()).unwrap_or(u8::MAX),
             secondary_evidence_count: 0,
+            negative_evidence_count: 0,
             call_position_rank: matched_call_line,
             lexical_tiebreak: completion_file.to_string(),
         },
         primary_evidence_kinds,
         secondary_evidence_kinds: Vec::new(),
+        negative_evidence_kinds: Vec::new(),
         support: Some(ImpactSliceCandidateSupportMetadata {
             edge_certainty: Some(edge_certainty),
             ..ImpactSliceCandidateSupportMetadata::default()
@@ -1575,11 +1577,13 @@ fn ruby_require_relative_scoring_summary(
         lane: ImpactSliceCandidateLane::RequireRelativeContinuation,
         primary_evidence_kinds,
         secondary_evidence_kinds,
+        negative_evidence_kinds: Vec::new(),
         score_tuple: ImpactSliceScoreTuple {
             source_rank: 0,
             lane_rank: tier2_lane_rank(ImpactSliceCandidateLane::RequireRelativeContinuation),
             primary_evidence_count: 1,
             secondary_evidence_count,
+            negative_evidence_count: 0,
             call_position_rank: call_line,
             lexical_tiebreak: completion_file.to_string(),
         },
@@ -1600,6 +1604,12 @@ fn evidence_kind_key(kind: ImpactSliceEvidenceKind) -> &'static str {
         ImpactSliceEvidenceKind::ParamToReturnFlow => "param_to_return_flow",
         ImpactSliceEvidenceKind::RequireRelativeEdge => "require_relative_edge",
         ImpactSliceEvidenceKind::ReturnFlow => "return_flow",
+    }
+}
+
+fn negative_evidence_kind_key(kind: ImpactSliceNegativeEvidenceKind) -> &'static str {
+    match kind {
+        ImpactSliceNegativeEvidenceKind::NoisyReturnHint => "noisy_return_hint",
     }
 }
 
@@ -1657,6 +1667,10 @@ fn tier2_scoring_summary(
         && !completion_return_hint
         && !completion_alias_hint
         && !completion_noise_hint;
+    let mut negative_evidence_kinds = Vec::new();
+    if completion_return_hint && completion_noise_hint {
+        negative_evidence_kinds.push(ImpactSliceNegativeEvidenceKind::NoisyReturnHint);
+    }
 
     let lane = if completion_return_hint
         || has_param_to_return_flow
@@ -1724,6 +1738,8 @@ fn tier2_scoring_summary(
     primary_evidence_kinds.dedup();
     secondary_evidence_kinds.sort_by_key(|kind| evidence_kind_key(*kind));
     secondary_evidence_kinds.dedup();
+    negative_evidence_kinds.sort_by_key(|kind| negative_evidence_kind_key(*kind));
+    negative_evidence_kinds.dedup();
 
     let support = if has_param_to_return_flow {
         Some(ImpactSliceCandidateSupportMetadata {
@@ -1743,11 +1759,13 @@ fn tier2_scoring_summary(
             primary_evidence_count: u8::try_from(primary_evidence_kinds.len()).unwrap_or(u8::MAX),
             secondary_evidence_count: u8::try_from(secondary_evidence_kinds.len())
                 .unwrap_or(u8::MAX),
+            negative_evidence_count: u8::try_from(negative_evidence_kinds.len()).unwrap_or(u8::MAX),
             call_position_rank: call_line,
             lexical_tiebreak: completion_file.to_string(),
         },
         primary_evidence_kinds,
         secondary_evidence_kinds,
+        negative_evidence_kinds,
         support,
     }
 }
@@ -1768,6 +1786,12 @@ fn compare_tier2_candidates(a: &Tier2Candidate, b: &Tier2Candidate) -> std::cmp:
                 .score_tuple
                 .primary_evidence_count
                 .cmp(&a.scoring.score_tuple.primary_evidence_count)
+        })
+        .then_with(|| {
+            a.scoring
+                .score_tuple
+                .negative_evidence_count
+                .cmp(&b.scoring.score_tuple.negative_evidence_count)
         })
         .then_with(|| {
             b.scoring
@@ -3293,11 +3317,13 @@ fn caller() -> i32 {
                 lane_rank: tier2_lane_rank(lane),
                 primary_evidence_count: u8::try_from(primary_evidence_kinds.len()).unwrap(),
                 secondary_evidence_count: u8::try_from(secondary_evidence_kinds.len()).unwrap(),
+                negative_evidence_count: 0,
                 call_position_rank,
                 lexical_tiebreak: lexical_tiebreak.to_string(),
             },
             primary_evidence_kinds,
             secondary_evidence_kinds,
+            negative_evidence_kinds: vec![],
             support: None,
         }
     }
@@ -3315,6 +3341,7 @@ fn caller() -> i32 {
                 lane_rank: tier2_lane_rank(ImpactSliceCandidateLane::ModuleCompanionFallback),
                 primary_evidence_count: 3,
                 secondary_evidence_count: 0,
+                negative_evidence_count: 0,
                 call_position_rank,
                 lexical_tiebreak: lexical_tiebreak.to_string(),
             },
@@ -3324,6 +3351,7 @@ fn caller() -> i32 {
                 ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad,
             ],
             secondary_evidence_kinds: vec![],
+            negative_evidence_kinds: vec![],
             support: Some(ImpactSliceCandidateSupportMetadata {
                 edge_certainty: Some(edge_certainty),
                 ..ImpactSliceCandidateSupportMetadata::default()
@@ -3595,6 +3623,108 @@ fn caller() -> i32 {
     }
 
     #[test]
+    fn bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion() {
+        let seed = test_symbol("rust:main.rs:fn:caller:1", "caller", "main.rs", 1);
+        let wrapper = test_symbol("rust:wrapper.rs:fn:wrap:3", "wrap", "wrapper.rs", 3);
+        let leaf = test_symbol("rust:leaf.rs:fn:source:1", "source", "leaf.rs", 1);
+        let helper = test_symbol(
+            "rust:zzz_final_helper.rs:fn:final_helper:1",
+            "final_helper",
+            "zzz_final_helper.rs",
+            1,
+        );
+        let index = SymbolIndex::build(vec![
+            seed.clone(),
+            wrapper.clone(),
+            leaf.clone(),
+            helper.clone(),
+        ]);
+        let refs = vec![
+            call_ref(seed.id.0.as_str(), wrapper.id.0.as_str(), "main.rs", 5),
+            call_ref(wrapper.id.0.as_str(), leaf.id.0.as_str(), "wrapper.rs", 5),
+            call_ref(wrapper.id.0.as_str(), helper.id.0.as_str(), "wrapper.rs", 6),
+        ];
+
+        let plan = plan_bounded_slice(
+            &[seed.file.clone()],
+            &[seed.file.clone()],
+            std::slice::from_ref(&seed),
+            &index,
+            &refs,
+            ImpactDirection::Callees,
+            ImpactSliceReasonKind::SeedFile,
+        );
+
+        assert_eq!(
+            plan.cache_update_paths,
+            vec![
+                "leaf.rs".to_string(),
+                "main.rs".to_string(),
+                "wrapper.rs".to_string(),
+            ]
+        );
+
+        let leaf_file = slice_selection_file(&plan.slice_selection, "leaf.rs");
+        assert_eq!(
+            leaf_file.reasons,
+            vec![ImpactSliceReasonMetadata {
+                seed_symbol_id: seed.id.0.clone(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("rust:wrapper.rs:fn:wrap:3".to_string()),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                scoring: Some(test_tier2_scoring(
+                    ImpactSliceCandidateLane::ReturnContinuation,
+                    vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    vec![ImpactSliceEvidenceKind::NamePathHint],
+                    5,
+                    "leaf.rs",
+                )),
+            }]
+        );
+        assert_eq!(
+            plan.slice_selection.pruned_candidates,
+            vec![dimpact::ImpactSlicePrunedCandidate {
+                seed_symbol_id: seed.id.0.clone(),
+                path: "zzz_final_helper.rs".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("rust:wrapper.rs:fn:wrap:3".to_string()),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                prune_reason: ImpactSlicePruneReason::RankedOut,
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    secondary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::CallsitePositionHint,
+                        ImpactSliceEvidenceKind::NamePathHint,
+                    ],
+                    negative_evidence_kinds: vec![ImpactSliceNegativeEvidenceKind::NoisyReturnHint,],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 2,
+                        secondary_evidence_count: 2,
+                        negative_evidence_count: 1,
+                        call_position_rank: 6,
+                        lexical_tiebreak: "zzz_final_helper.rs".to_string(),
+                    },
+                    support: None,
+                }),
+            }]
+        );
+    }
+
+    #[test]
     fn bounded_slice_plan_prefers_alias_continuation_over_later_adapter_helper_noise() {
         let seed = test_symbol("rust:main.rs:fn:caller:1", "caller", "main.rs", 1);
         let adapter = test_symbol("rust:adapter.rs:fn:wrap:3", "wrap", "adapter.rs", 3);
@@ -3794,11 +3924,13 @@ fn caller() -> i32 {
                         ImpactSliceEvidenceKind::ReturnFlow,
                     ],
                     secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
                     score_tuple: ImpactSliceScoreTuple {
                         source_rank: 0,
                         lane_rank: 0,
                         primary_evidence_count: 3,
                         secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
                         call_position_rank: 5,
                         lexical_tiebreak: "step.rs".to_string(),
                     },

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -129,6 +129,8 @@ pub struct ImpactSliceCandidateScoringSummary {
     pub lane: ImpactSliceCandidateLane,
     pub primary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
     pub secondary_evidence_kinds: Vec<ImpactSliceEvidenceKind>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub negative_evidence_kinds: Vec<ImpactSliceNegativeEvidenceKind>,
     pub score_tuple: ImpactSliceScoreTuple,
     #[serde(
         default,
@@ -169,6 +171,12 @@ pub enum ImpactSliceEvidenceKind {
     NamePathHint,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactSliceNegativeEvidenceKind {
+    NoisyReturnHint,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ImpactSliceCandidateSupportMetadata {
     #[serde(default, skip_serializing_if = "impact_slice_bool_is_false")]
@@ -194,6 +202,10 @@ fn impact_slice_bool_is_false(value: &bool) -> bool {
     !*value
 }
 
+fn impact_slice_u8_is_zero(value: &u8) -> bool {
+    *value == 0
+}
+
 fn impact_slice_candidate_support_is_absent(
     support: &Option<ImpactSliceCandidateSupportMetadata>,
 ) -> bool {
@@ -217,6 +229,8 @@ pub struct ImpactSliceScoreTuple {
     pub lane_rank: u8,
     pub primary_evidence_count: u8,
     pub secondary_evidence_count: u8,
+    #[serde(default, skip_serializing_if = "impact_slice_u8_is_zero")]
+    pub negative_evidence_count: u8,
     pub call_position_rank: u32,
     pub lexical_tiebreak: String,
 }
@@ -308,6 +322,7 @@ pub enum ImpactWitnessSliceRankingBasis {
     SourceKind,
     Lane,
     PrimaryEvidenceCount,
+    NegativeEvidenceCount,
     SecondaryEvidenceCount,
     CallsitePosition,
     LexicalTiebreak,
@@ -859,6 +874,11 @@ fn selected_vs_pruned_summary(
             "it had more primary evidence ({} > {})",
             selected.score_tuple.primary_evidence_count, pruned.score_tuple.primary_evidence_count
         ),
+        ImpactWitnessSliceRankingBasis::NegativeEvidenceCount => format!(
+            "it had less negative evidence ({} < {})",
+            selected.score_tuple.negative_evidence_count,
+            pruned.score_tuple.negative_evidence_count
+        ),
         ImpactWitnessSliceRankingBasis::SecondaryEvidenceCount => format!(
             "it had more secondary evidence ({} > {})",
             selected.score_tuple.secondary_evidence_count,
@@ -936,6 +956,17 @@ fn selected_reason_ranking_basis(
             return Some(ImpactWitnessSliceRankingBasis::PrimaryEvidenceCount);
         }
         std::cmp::Ordering::Less => return None,
+        std::cmp::Ordering::Equal => {}
+    }
+    match selected
+        .score_tuple
+        .negative_evidence_count
+        .cmp(&pruned.score_tuple.negative_evidence_count)
+    {
+        std::cmp::Ordering::Less => {
+            return Some(ImpactWitnessSliceRankingBasis::NegativeEvidenceCount);
+        }
+        std::cmp::Ordering::Greater => return None,
         std::cmp::Ordering::Equal => {}
     }
     match selected
@@ -2751,11 +2782,13 @@ fn foo() { bar(); }
                     ImpactSliceEvidenceKind::ReturnFlow,
                 ],
                 secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::CallsitePositionHint],
+                negative_evidence_kinds: vec![],
                 score_tuple: ImpactSliceScoreTuple {
                     source_rank: 0,
                     lane_rank: 0,
                     primary_evidence_count: 2,
                     secondary_evidence_count: 1,
+                    negative_evidence_count: 0,
                     call_position_rank: 8,
                     lexical_tiebreak: "leaf.rs".to_string(),
                 },
@@ -2823,11 +2856,13 @@ fn foo() { bar(); }
                     lane: ImpactSliceCandidateLane::AliasContinuation,
                     primary_evidence_kinds: vec![ImpactSliceEvidenceKind::AssignedResult],
                     secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
                     score_tuple: ImpactSliceScoreTuple {
                         source_rank: 0,
                         lane_rank: 1,
                         primary_evidence_count: 1,
                         secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
                         call_position_rank: 7,
                         lexical_tiebreak: "aaa_helper.rs".to_string(),
                     },
@@ -2906,11 +2941,13 @@ fn foo() { bar(); }
                         ImpactSliceEvidenceKind::ExplicitRequireRelativeLoad,
                     ],
                     secondary_evidence_kinds: vec![],
+                    negative_evidence_kinds: vec![],
                     score_tuple: ImpactSliceScoreTuple {
                         source_rank: 0,
                         lane_rank: 3,
                         primary_evidence_count: 2,
                         secondary_evidence_count: 0,
+                        negative_evidence_count: 0,
                         call_position_rank: 0,
                         lexical_tiebreak: "lib/leaf.rb".to_string(),
                     },
@@ -2935,11 +2972,13 @@ fn foo() { bar(); }
                     lane: ImpactSliceCandidateLane::ModuleCompanionFallback,
                     primary_evidence_kinds: vec![ImpactSliceEvidenceKind::CompanionFileMatch],
                     secondary_evidence_kinds: vec![],
+                    negative_evidence_kinds: vec![],
                     score_tuple: ImpactSliceScoreTuple {
                         source_rank: 1,
                         lane_rank: 3,
                         primary_evidence_count: 1,
                         secondary_evidence_count: 0,
+                        negative_evidence_count: 0,
                         call_position_rank: 0,
                         lexical_tiebreak: "lib/helper.rb".to_string(),
                     },
@@ -3464,11 +3503,13 @@ fn foo() { bar(); }
             lane: ImpactSliceCandidateLane::ReturnContinuation,
             primary_evidence_kinds: vec![ImpactSliceEvidenceKind::ReturnFlow],
             secondary_evidence_kinds: vec![],
+            negative_evidence_kinds: vec![],
             score_tuple: ImpactSliceScoreTuple {
                 source_rank: 0,
                 lane_rank: 0,
                 primary_evidence_count: 1,
                 secondary_evidence_count: 0,
+                negative_evidence_count: 0,
                 call_position_rank: 3,
                 lexical_tiebreak: "leaf.rs".to_string(),
             },
@@ -3508,11 +3549,13 @@ fn foo() { bar(); }
                 ImpactSliceEvidenceKind::ParamToReturnFlow,
             ],
             secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+            negative_evidence_kinds: vec![ImpactSliceNegativeEvidenceKind::NoisyReturnHint],
             score_tuple: ImpactSliceScoreTuple {
                 source_rank: 1,
                 lane_rank: 3,
                 primary_evidence_count: 4,
                 secondary_evidence_count: 1,
+                negative_evidence_count: 1,
                 call_position_rank: 0,
                 lexical_tiebreak: "demo/helper.rb".to_string(),
             },
@@ -3543,6 +3586,11 @@ fn foo() { bar(); }
                 "edge_certainty": "dynamic_fallback"
             })
         );
+        assert_eq!(
+            value["negative_evidence_kinds"],
+            serde_json::json!(["noisy_return_hint"])
+        );
+        assert_eq!(value["score_tuple"]["negative_evidence_count"], 1);
 
         let round_tripped: ImpactSliceCandidateScoringSummary =
             serde_json::from_value(value).expect("deserialize scoring summary");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,13 @@ pub use impact::{
     ImpactRiskLevel, ImpactRiskSummary, ImpactSliceBridgeKind, ImpactSliceCandidateLane,
     ImpactSliceCandidateScoringSummary, ImpactSliceCandidateSourceKind,
     ImpactSliceCandidateSupportMetadata, ImpactSliceEvidenceKind, ImpactSliceFileMetadata,
-    ImpactSlicePlannerKind, ImpactSlicePruneReason, ImpactSlicePrunedCandidate,
-    ImpactSliceReasonKind, ImpactSliceReasonMetadata, ImpactSliceScopes, ImpactSliceScoreTuple,
-    ImpactSliceSelectionSummary, ImpactSliceSupportEdgeCertainty, ImpactSummary, ImpactWitness,
-    ImpactWitnessHop, ImpactWitnessSliceContext, ImpactWitnessSliceFileContext,
-    ImpactWitnessSliceRankingBasis, ImpactWitnessSliceSelectedVsPrunedReason,
-    attach_slice_selection_summary, build_project_graph, compute_impact, path_is_ignored,
+    ImpactSliceNegativeEvidenceKind, ImpactSlicePlannerKind, ImpactSlicePruneReason,
+    ImpactSlicePrunedCandidate, ImpactSliceReasonKind, ImpactSliceReasonMetadata,
+    ImpactSliceScopes, ImpactSliceScoreTuple, ImpactSliceSelectionSummary,
+    ImpactSliceSupportEdgeCertainty, ImpactSummary, ImpactWitness, ImpactWitnessHop,
+    ImpactWitnessSliceContext, ImpactWitnessSliceFileContext, ImpactWitnessSliceRankingBasis,
+    ImpactWitnessSliceSelectedVsPrunedReason, attach_slice_selection_summary, build_project_graph,
+    compute_impact, path_is_ignored,
 };
 pub use ir::{Symbol, SymbolId, SymbolKind, TextRange};
 pub use languages::LanguageKind;

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -320,6 +320,79 @@ fn caller() {
     (dir, path)
 }
 
+fn setup_cross_file_returnish_helper_noise_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::write(
+        path.join("leaf.rs"),
+        r#"pub fn source(v: i32) -> i32 {
+    v + 1
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("zzz_final_helper.rs"),
+        r#"pub fn final_helper(v: i32) -> i32 {
+    v - 1
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("wrapper.rs"),
+        r#"use crate::leaf;
+use crate::zzz_final_helper;
+
+pub fn wrap(left: i32, right: i32) -> i32 {
+    let mid = leaf::source(right);
+    let _side = zzz_final_helper::final_helper(left);
+    mid
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod wrapper;
+mod zzz_final_helper;
+
+fn caller() {
+    let x = 1;
+    let y = 2;
+    let out = wrapper::wrap(x, y);
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod wrapper;
+mod zzz_final_helper;
+
+fn caller() {
+    let x = 3;
+    let y = 2;
+    let out = wrapper::wrap(x, y);
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_cross_file_dual_wrapper_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -1334,6 +1407,135 @@ fn pdg_slice_selection_prefers_wrapper_return_leaf_over_earlier_noise_candidate(
         prop_dot.contains("\"main.rs:use:y:8\" -> \"main.rs:def:out:8\""),
         "expected propagation to recover the leaf-backed wrapper-return bridge, got:\n{}",
         prop_dot
+    );
+}
+
+#[test]
+fn pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite() {
+    let (_tmp, repo) = setup_cross_file_returnish_helper_noise_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &["--direction", "callees", "--with-pdg", "--format", "dot"],
+    );
+    let prop = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--with-propagation",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"leaf.rs:def:v:1\""),
+        "expected bounded slice scope to keep the real leaf return nodes, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"zzz_final_helper.rs:def:v:1\""),
+        "unexpected return-ish helper noise entered the bounded slice scope, got:\n{}",
+        pdg
+    );
+
+    let slice_selection = &prop["summary"]["slice_selection"];
+    let paths: Vec<&str> = slice_selection["files"]
+        .as_array()
+        .expect("slice_selection.files array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(paths, vec!["leaf.rs", "main.rs", "wrapper.rs"]);
+
+    let leaf = slice_selection_file(slice_selection, "leaf.rs");
+    assert!(
+        leaf["reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason["tier"] == 2
+                    && reason["kind"] == "bridge_completion_file"
+                    && reason["via_symbol_id"] == "rust:wrapper.rs:fn:wrap:4"
+                    && reason["via_path"] == "wrapper.rs"
+                    && reason["bridge_kind"] == "wrapper_return"
+                    && reason["scoring"]
+                        == serde_json::json!({
+                            "source_kind": "graph_second_hop",
+                            "lane": "return_continuation",
+                            "primary_evidence_kinds": [
+                                "assigned_result",
+                                "return_flow"
+                            ],
+                            "secondary_evidence_kinds": [
+                                "name_path_hint"
+                            ],
+                            "score_tuple": {
+                                "source_rank": 0,
+                                "lane_rank": 0,
+                                "primary_evidence_count": 2,
+                                "secondary_evidence_count": 1,
+                                "call_position_rank": 5,
+                                "lexical_tiebreak": "leaf.rs"
+                            }
+                        })
+            })),
+        "expected leaf to keep the clean wrapper-return score: {prop:#}"
+    );
+    assert!(
+        slice_selection["pruned_candidates"]
+            .as_array()
+            .is_some_and(|candidates| candidates.iter().any(|candidate| {
+                candidate["path"] == "zzz_final_helper.rs"
+                    && candidate["prune_reason"] == "ranked_out"
+                    && candidate["via_symbol_id"] == "rust:wrapper.rs:fn:wrap:4"
+                    && candidate["bridge_kind"] == "wrapper_return"
+                    && candidate["scoring"]
+                        == serde_json::json!({
+                            "source_kind": "graph_second_hop",
+                            "lane": "return_continuation",
+                            "primary_evidence_kinds": [
+                                "assigned_result",
+                                "return_flow"
+                            ],
+                            "secondary_evidence_kinds": [
+                                "callsite_position_hint",
+                                "name_path_hint"
+                            ],
+                            "negative_evidence_kinds": [
+                                "noisy_return_hint"
+                            ],
+                            "score_tuple": {
+                                "source_rank": 0,
+                                "lane_rank": 0,
+                                "primary_evidence_count": 2,
+                                "secondary_evidence_count": 2,
+                                "negative_evidence_count": 1,
+                                "call_position_rank": 6,
+                                "lexical_tiebreak": "zzz_final_helper.rs"
+                            }
+                        })
+            })),
+        "expected return-ish helper noise to remain only as ranked-out negative evidence metadata: {prop:#}"
+    );
+
+    let witness = &prop["impacted_witnesses"]["rust:leaf.rs:fn:source:1"];
+    let leaf_context = witness_slice_file(witness, "leaf.rs");
+    assert_eq!(
+        leaf_context["selected_vs_pruned_reasons"],
+        serde_json::json!([{
+            "via_symbol_id": "rust:wrapper.rs:fn:wrap:4",
+            "via_path": "wrapper.rs",
+            "selected_bridge_kind": "wrapper_return",
+            "pruned_path": "zzz_final_helper.rs",
+            "prune_reason": "ranked_out",
+            "pruned_bridge_kind": "wrapper_return",
+            "selected_better_by": "negative_evidence_count",
+            "summary": "selected over zzz_final_helper.rs because it had less negative evidence (0 < 1)",
+        }])
     );
 }
 


### PR DESCRIPTION
## Summary
- add planner-side negative evidence for return-ish helper noise and compare candidates on that suppressing signal
- keep the new negative evidence in slice scoring JSON/witness ranking metadata without attempting the broader G9 witness redesign yet
- add unit and CLI regressions for a concrete wrapper-return misselection where a later `final_helper` candidate used to outrank the real leaf

## Testing
- cargo test