### PR TITLE
planner: tighten ruby dynamic fallback matching

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1011,12 +1011,24 @@ impl Tier2SemanticEvidence {
 struct RubyNarrowFallbackBoundaryEvidence {
     explicit_require_relative_loads: std::collections::BTreeSet<String>,
     literal_dynamic_targets: std::collections::BTreeMap<String, u32>,
+    literal_dynamic_target_hints: std::collections::BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
 struct RubyNarrowFallbackCandidateEvidence {
     matched_call_line: u32,
     edge_certainty: dimpact::ImpactSliceSupportEdgeCertainty,
+}
+
+fn ruby_dynamic_target_hints(target: &str) -> std::collections::BTreeSet<String> {
+    let mut hints = std::collections::BTreeSet::new();
+    hints.insert(target.to_string());
+    for (idx, ch) in target.char_indices() {
+        if ch == '_' && idx > 0 {
+            hints.insert(target[..=idx].to_string());
+        }
+    }
+    hints
 }
 
 fn symbol_id_node_name(node_id: &str) -> Option<&str> {
@@ -1213,16 +1225,22 @@ fn collect_ruby_narrow_fallback_boundary_evidence(
                 acc
             },
         );
+    let literal_dynamic_target_hints = literal_dynamic_targets
+        .keys()
+        .flat_map(|target| ruby_dynamic_target_hints(target))
+        .collect();
 
     RubyNarrowFallbackBoundaryEvidence {
         explicit_require_relative_loads,
         literal_dynamic_targets,
+        literal_dynamic_target_hints,
     }
 }
 
 fn collect_ruby_narrow_fallback_candidate_evidence(
     candidate_file: &str,
     literal_dynamic_targets: &std::collections::BTreeMap<String, u32>,
+    literal_dynamic_target_hints: &std::collections::BTreeSet<String>,
 ) -> Option<RubyNarrowFallbackCandidateEvidence> {
     if literal_dynamic_targets.is_empty() || !candidate_file.ends_with(".rb") {
         return None;
@@ -1249,7 +1267,13 @@ fn collect_ruby_narrow_fallback_candidate_evidence(
     let has_dynamic_runtime = src.contains("def method_missing")
         || src.contains("def respond_to_missing?")
         || src.contains("define_method");
+    let has_related_dynamic_target_hint = literal_dynamic_target_hints
+        .iter()
+        .any(|hint| !hint.is_empty() && src.contains(hint));
     if !has_exact_target_match && !has_dynamic_runtime {
+        return None;
+    }
+    if !has_exact_target_match && !has_related_dynamic_target_hint {
         return None;
     }
 
@@ -1327,6 +1351,7 @@ fn collect_ruby_narrow_fallback_candidates(
             let candidate_evidence = collect_ruby_narrow_fallback_candidate_evidence(
                 candidate_file.as_str(),
                 &boundary_evidence.literal_dynamic_targets,
+                &boundary_evidence.literal_dynamic_target_hints,
             )?;
             Some(Tier2Candidate {
                 path: candidate_file.clone(),
@@ -4316,6 +4341,102 @@ fn caller() -> i32 {
     }
 
     #[test]
+    fn ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint() {
+        let dir = TempDir::new().expect("tempdir");
+        let app_dir = dir.path().join("app");
+        let lib_dir = dir.path().join("lib");
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::create_dir_all(&lib_dir).unwrap();
+
+        let main = app_dir.join("main.rb");
+        let router = lib_dir.join("router.rb");
+        let generic_runtime = lib_dir.join("aaa_runtime.rb");
+        let route_runtime = lib_dir.join("route_runtime.rb");
+        fs::write(
+            &main,
+            "require_relative \"../lib/router\"\n\nclass Main\n  def run\n    Router.new.run_created(\"alpha\")\n  end\nend\n",
+        )
+        .unwrap();
+        fs::write(
+            &router,
+            "require_relative \"aaa_runtime\"\nrequire_relative \"route_runtime\"\n\nclass Router\n  def initialize\n    @runtime = RouteRuntime.new\n  end\n\n  def run_created(payload)\n    @runtime.public_send(\"route_created\", payload)\n  end\nend\n",
+        )
+        .unwrap();
+        fs::write(
+            &generic_runtime,
+            "class GenericRuntime\n  def method_missing(name, *args)\n    return args.first if args.any?\n    super\n  end\n\n  def respond_to_missing?(name, include_private = false)\n    true\n  end\nend\n",
+        )
+        .unwrap();
+        fs::write(
+            &route_runtime,
+            "class RouteRuntime\n  def method_missing(name, *args)\n    return args.first if name.to_s.start_with?(\"route_\")\n    super\n  end\n\n  def respond_to_missing?(name, include_private = false)\n    name.to_s.start_with?(\"route_\") || super\n  end\nend\n",
+        )
+        .unwrap();
+
+        let main_file = main.to_string_lossy().to_string();
+        let router_file = router.to_string_lossy().to_string();
+        let generic_runtime_file = generic_runtime.to_string_lossy().to_string();
+        let route_runtime_file = route_runtime.to_string_lossy().to_string();
+
+        let boundary = dimpact::Symbol {
+            id: SymbolId("ruby:lib/router.rb:method:run_created:9".to_string()),
+            name: "run_created".to_string(),
+            kind: dimpact::SymbolKind::Method,
+            file: router_file.clone(),
+            range: dimpact::TextRange {
+                start_line: 9,
+                end_line: 11,
+            },
+            language: "ruby".to_string(),
+        };
+        let boundary_evidence = collect_ruby_narrow_fallback_boundary_evidence(&boundary);
+        assert_eq!(
+            boundary_evidence.explicit_require_relative_loads,
+            std::collections::BTreeSet::from([
+                generic_runtime_file.clone(),
+                route_runtime_file.clone(),
+            ])
+        );
+        assert_eq!(
+            boundary_evidence.literal_dynamic_target_hints,
+            std::collections::BTreeSet::from(["route_".to_string(), "route_created".to_string(),])
+        );
+        assert!(
+            collect_ruby_narrow_fallback_candidate_evidence(
+                &generic_runtime_file,
+                &boundary_evidence.literal_dynamic_targets,
+                &boundary_evidence.literal_dynamic_target_hints,
+            )
+            .is_none()
+        );
+        let route_runtime_evidence = collect_ruby_narrow_fallback_candidate_evidence(
+            &route_runtime_file,
+            &boundary_evidence.literal_dynamic_targets,
+            &boundary_evidence.literal_dynamic_target_hints,
+        )
+        .expect("route runtime fallback evidence");
+        assert_eq!(route_runtime_evidence.matched_call_line, 10);
+        assert_eq!(
+            route_runtime_evidence.edge_certainty,
+            dimpact::ImpactSliceSupportEdgeCertainty::DynamicFallback
+        );
+
+        let candidates = collect_ruby_narrow_fallback_candidates(
+            &main_file,
+            &std::collections::BTreeSet::new(),
+            &boundary,
+            &router_file,
+        );
+        assert_eq!(
+            candidates
+                .into_iter()
+                .map(|candidate| candidate.path)
+                .collect::<Vec<_>>(),
+            vec![route_runtime_file]
+        );
+    }
+
+    #[test]
     fn bounded_slice_plan_selects_ruby_method_missing_companion_as_narrow_fallback() {
         let dir = TempDir::new().expect("tempdir");
         let app_dir = dir.path().join("app");
@@ -4370,6 +4491,7 @@ fn caller() -> i32 {
         let candidate_evidence = collect_ruby_narrow_fallback_candidate_evidence(
             &runtime_file,
             &boundary_evidence.literal_dynamic_targets,
+            &boundary_evidence.literal_dynamic_target_hints,
         )
         .expect("runtime fallback evidence");
         assert_eq!(candidate_evidence.matched_call_line, 9);

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -970,6 +970,88 @@ end
     (dir, path)
 }
 
+fn setup_ruby_dynamic_send_runtime_noise_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::create_dir_all(path.join("lib")).unwrap();
+    fs::create_dir_all(path.join("app")).unwrap();
+    fs::write(
+        path.join("lib/aaa_runtime.rb"),
+        r#"class GenericRuntime
+  def method_missing(name, *args)
+    return args.first if args.any?
+    super
+  end
+
+  def respond_to_missing?(name, include_private = false)
+    true
+  end
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/route_runtime.rb"),
+        r#"class RuntimeProxy
+  def method_missing(name, *args)
+    return args.first if name.to_s.start_with?("route_")
+    super
+  end
+
+  def respond_to_missing?(name, include_private = false)
+    name.to_s.start_with?("route_") || super
+  end
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/service.rb"),
+        r#"require_relative 'aaa_runtime'
+require_relative 'route_runtime'
+
+def bounce(payload)
+  runtime = Object.const_get("RuntimeProxy").new
+  runtime.public_send("route_created", payload)
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("app/runner.rb"),
+        r##"require_relative '../lib/service'
+
+def entry(seed)
+  prepared = "#{seed}-v1"
+  reply = bounce(prepared)
+  return reply
+end
+"##,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("app/runner.rb"),
+        r##"require_relative '../lib/service'
+
+def entry(seed)
+  prepared = "#{seed}-v2"
+  reply = bounce(prepared)
+  return reply
+end
+"##,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn diff_text(repo: &std::path::Path) -> String {
     let diff_out = git(repo, &["diff", "--no-ext-diff", "--unified=0"]);
     String::from_utf8(diff_out.stdout).unwrap()
@@ -2191,6 +2273,60 @@ fn pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_nois
         prop_dot.contains("\"app/runner.rb:use:prepared:5\" -> \"app/runner.rb:def:reply:5\""),
         "expected propagation to recover the Ruby leaf-backed summary bridge, got:\n{}",
         prop_dot
+    );
+}
+
+#[test]
+fn pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise() {
+    let (_tmp, repo) = setup_ruby_dynamic_send_runtime_noise_repo();
+    let diff = diff_text(&repo);
+
+    let prop = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "json",
+        ],
+    );
+
+    let slice_selection = &prop["summary"]["slice_selection"];
+    let paths: Vec<&str> = slice_selection["files"]
+        .as_array()
+        .expect("slice_selection.files array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["app/runner.rb", "lib/route_runtime.rb", "lib/service.rb"]
+    );
+    assert_eq!(
+        slice_selection["pruned_candidates"],
+        serde_json::json!([]),
+        "expected unrelated generic dynamic runtime to be filtered before tier-2 ranking: {prop:#}"
+    );
+
+    let route_runtime = slice_selection_file(slice_selection, "lib/route_runtime.rb");
+    assert!(
+        route_runtime["reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason["via_symbol_id"] == "ruby:lib/service.rb:method:bounce:4"
+                    && reason["via_path"] == "lib/service.rb"
+            })),
+        "expected family-specific runtime to remain selected through lib/service.rb after filtering generic runtime noise: {prop:#}"
+    );
+    assert!(
+        !prop["impacted_files"]
+            .as_array()
+            .is_some_and(|files| files.iter().any(|path| path == "lib/aaa_runtime.rb")),
+        "unexpected generic dynamic runtime survived into impacted_files: {prop:#}"
     );
 }
 


### PR DESCRIPTION
## Summary
- tighten true Ruby narrow fallback candidate admission so generic method_missing runtimes are filtered unless they relate to the literal dynamic-send target family
- derive boundary-level dynamic target hints from literal send/public_send names and thread them through narrow fallback candidate collection
- add unit and CLI regressions for a noisy dynamic-send case where a generic runtime helper should no longer survive fallback selection

## Testing
- git diff --check
- cargo test --offline --bin dimpact ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint
- cargo test --offline --bin dimpact bounded_slice_plan_selects_ruby_method_missing_companion_as_narrow_fallback
- cargo test --offline --test cli_pdg_propagation pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise