### PR TITLE
docs: extend eval set with evidence conflicts

### DIFF
--- a/docs/g8-6-evidence-driven-eval-set.json
+++ b/docs/g8-6-evidence-driven-eval-set.json
@@ -1,7 +1,7 @@
 {
-  "generated_by": "manual G8-6 design note",
+  "generated_by": "manual G8-6/G9 eval-set extension note",
   "repo_root": "/home/shioriko/src/github.com/n01e0/dimpact",
-  "purpose": "fixed evidence-driven evaluation set for semantic scoring, true narrow fallback, and winning-evidence witness explanation on current HEAD",
+  "purpose": "fixed evidence-driven evaluation set covering G8 baseline plus G9 evidence-conflict regressions for negative evidence, semantic tie-breaks, dynamic fallback filtering, and losing-side witness reasons",
   "defaults": {
     "engine": "ts",
     "cli_lanes": [
@@ -9,6 +9,11 @@
       "propagation"
     ],
     "note": "treat current HEAD planner/unit tests as first-class lanes when the evidence surface is locked there more directly than in CLI output"
+  },
+  "totals": {
+    "cases": 7,
+    "rust": 3,
+    "ruby": 4
   },
   "cases": [
     {
@@ -63,20 +68,6 @@
           "--exact"
         ]
       },
-      "repro": {
-        "layout": [
-          "step.rs",
-          "later.rs",
-          "wrapper.rs",
-          "main.rs"
-        ],
-        "shape": [
-          "step.rs keeps input -> forwarded -> return continuity",
-          "later.rs is a neutral helper reached from the same wrapper",
-          "wrapper.rs calls both step::step(a) and later::later(a)",
-          "main.rs mutates input from 1 to 2"
-        ]
-      },
       "expected_outcome": {
         "selected_paths": [
           "main.rs",
@@ -91,15 +82,7 @@
         ],
         "selected_via_symbol_id": "rust:wrapper.rs:fn:wrap:4",
         "selected_better_by": "primary_evidence_count",
-        "witness_symbol_id": "rust:step.rs:fn:step:1",
-        "dot_assertions": {
-          "contains": [
-            "\"step.rs:def:forwarded:2\""
-          ],
-          "excludes": [
-            "\"later.rs:def:shadow:2\""
-          ]
-        }
+        "witness_symbol_id": "rust:step.rs:fn:step:1"
       },
       "expected_fields": {
         "selected_scoring": {
@@ -146,6 +129,230 @@
       ]
     },
     {
+      "case_id": "rust-returnish-helper-negative-evidence",
+      "lang": "rust",
+      "source_kind": "integration_fixture_plus_unit_guard",
+      "source": [
+        "src/bin/dimpact.rs::bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion",
+        "tests/cli_pdg_propagation.rs::setup_cross_file_returnish_helper_noise_repo",
+        "tests/cli_pdg_propagation.rs::pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite",
+        "src/impact.rs::selected_vs_pruned_reason_derives_losing_side_reason_from_negative_evidence"
+      ],
+      "failure_kind": "suppressing_regression",
+      "primary_view": "dot+json+unit_test",
+      "focus": "return-ish helper noise stays ranked out once noisy_return_hint is introduced as negative evidence",
+      "direction": "callees",
+      "lanes": {
+        "pdg": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-pdg",
+          "--format",
+          "dot"
+        ],
+        "propagation": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "json"
+        ]
+      },
+      "test_lanes": {
+        "integration": [
+          "cargo",
+          "test",
+          "--test",
+          "cli_pdg_propagation",
+          "pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite",
+          "--",
+          "--exact"
+        ],
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion",
+          "--",
+          "--exact"
+        ]
+      },
+      "expected_outcome": {
+        "selected_paths": [
+          "leaf.rs",
+          "main.rs",
+          "wrapper.rs"
+        ],
+        "pruned_candidates": [
+          {
+            "path": "zzz_final_helper.rs",
+            "prune_reason": "ranked_out"
+          }
+        ],
+        "selected_better_by": "negative_evidence_count",
+        "witness_symbol_id": "rust:leaf.rs:fn:source:1"
+      },
+      "expected_fields": {
+        "selected_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "return_continuation",
+          "primary_evidence_kinds": [
+            "assigned_result",
+            "return_flow"
+          ],
+          "secondary_evidence_kinds": [
+            "name_path_hint"
+          ]
+        },
+        "pruned_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "return_continuation",
+          "primary_evidence_kinds": [
+            "assigned_result",
+            "return_flow"
+          ],
+          "secondary_evidence_kinds": [
+            "callsite_position_hint",
+            "name_path_hint"
+          ],
+          "negative_evidence_kinds": [
+            "noisy_return_hint"
+          ],
+          "score_tuple": {
+            "negative_evidence_count": 1
+          }
+        },
+        "witness_reason": {
+          "selected_better_by": "negative_evidence_count",
+          "losing_side_reason": "negative_evidence=noisy_return_hint",
+          "summary": "selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint"
+        }
+      },
+      "regression_catch": [
+        "later return-ish helper wins again despite negative evidence",
+        "negative_evidence_kinds disappears from ranked-out metadata",
+        "losing-side negative evidence stops appearing in witness output"
+      ]
+    },
+    {
+      "case_id": "rust-semantic-support-tiebreak",
+      "lang": "rust",
+      "source_kind": "integration_fixture_plus_unit_guard",
+      "source": [
+        "src/bin/dimpact.rs::bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint",
+        "tests/cli_pdg_propagation.rs::setup_cross_file_semantic_support_competition_repo",
+        "tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint"
+      ],
+      "failure_kind": "tiebreak_regression",
+      "primary_view": "dot+json+unit_test",
+      "focus": "same-kind Rust return candidates are decided by semantic_support_rank before later callsite hints",
+      "direction": "callees",
+      "lanes": {
+        "pdg": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-pdg",
+          "--format",
+          "dot"
+        ],
+        "propagation": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "json"
+        ]
+      },
+      "test_lanes": {
+        "integration": [
+          "cargo",
+          "test",
+          "--test",
+          "cli_pdg_propagation",
+          "pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint",
+          "--",
+          "--exact"
+        ],
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint",
+          "--",
+          "--exact"
+        ]
+      },
+      "expected_outcome": {
+        "selected_paths": [
+          "main.rs",
+          "steady.rs",
+          "wrapper.rs"
+        ],
+        "pruned_candidates": [
+          {
+            "path": "plain.rs",
+            "prune_reason": "ranked_out"
+          }
+        ],
+        "selected_better_by": "semantic_support_rank",
+        "witness_symbol_id": "rust:steady.rs:fn:carry:1"
+      },
+      "expected_fields": {
+        "selected_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "return_continuation",
+          "primary_evidence_kinds": [
+            "assigned_result",
+            "param_to_return_flow",
+            "return_flow"
+          ],
+          "secondary_evidence_kinds": [
+            "name_path_hint"
+          ],
+          "score_tuple": {
+            "semantic_support_rank": 3
+          },
+          "support": {
+            "local_dfg_support": true
+          }
+        },
+        "pruned_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "return_continuation",
+          "primary_evidence_kinds": [
+            "assigned_result",
+            "param_to_return_flow",
+            "return_flow"
+          ],
+          "secondary_evidence_kinds": [
+            "callsite_position_hint",
+            "name_path_hint"
+          ],
+          "score_tuple": {
+            "semantic_support_rank": 2
+          },
+          "support": {
+            "local_dfg_support": true
+          }
+        },
+        "witness_reason": {
+          "selected_better_by": "semantic_support_rank",
+          "summary": "selected over plain.rs because it had stronger semantic support (3 > 2)"
+        }
+      },
+      "regression_catch": [
+        "same-kind candidates are decided by later callsite hint again",
+        "semantic_support_rank disappears from scoring metadata",
+        "the stronger semantic leaf loses to plain.rs"
+      ]
+    },
+    {
       "case_id": "ruby-method-missing-companion-narrow-fallback",
       "lang": "ruby",
       "source_kind": "planner_unit_fixture",
@@ -170,24 +377,7 @@
           "--exact"
         ]
       },
-      "repro": {
-        "layout": [
-          "app/main.rb",
-          "lib/router.rb",
-          "lib/runtime.rb"
-        ],
-        "shape": [
-          "app/main.rb calls Router#run_created",
-          "lib/router.rb require_relative loads runtime.rb and uses public_send(\"route_created\", payload)",
-          "lib/runtime.rb implements RuntimeProxy#method_missing and respond_to_missing?"
-        ]
-      },
       "expected_outcome": {
-        "cache_update_path_suffixes": [
-          "app/main.rb",
-          "lib/router.rb",
-          "lib/runtime.rb"
-        ],
         "selected_reason": {
           "tier": 3,
           "kind": "module_companion_file",
@@ -220,16 +410,101 @@
           "support": {
             "edge_certainty": "dynamic_fallback"
           }
-        },
-        "explanation_surface": {
-          "selected_vs_pruned_reasons": "absent",
-          "pruned_candidates": []
         }
       },
       "regression_catch": [
         "runtime companion is no longer selected as bounded narrow fallback",
         "one of companion_file_match, dynamic_dispatch_literal_target, or explicit_require_relative_load drops from scoring",
         "narrow fallback gets mixed into graph-first selected reasons"
+      ]
+    },
+    {
+      "case_id": "ruby-dynamic-runtime-target-family-filter",
+      "lang": "ruby",
+      "source_kind": "planner_unit_plus_integration_fixture",
+      "source": [
+        "src/bin/dimpact.rs::ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint",
+        "tests/cli_pdg_propagation.rs::setup_ruby_dynamic_send_runtime_noise_repo",
+        "tests/cli_pdg_propagation.rs::pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise"
+      ],
+      "failure_kind": "fallback_noise_filter_regression",
+      "primary_view": "json+unit_test",
+      "focus": "generic dynamic runtime noise is filtered before candidate materialization unless it matches the literal target family",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--direction",
+          "callees",
+          "--lang",
+          "ruby",
+          "--with-propagation",
+          "--format",
+          "json"
+        ]
+      },
+      "test_lanes": {
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint",
+          "--",
+          "--exact"
+        ],
+        "integration": [
+          "cargo",
+          "test",
+          "--test",
+          "cli_pdg_propagation",
+          "pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise",
+          "--",
+          "--exact"
+        ]
+      },
+      "expected_outcome": {
+        "selected_paths": [
+          "app/runner.rb",
+          "lib/route_runtime.rb",
+          "lib/service.rb"
+        ],
+        "pruned_candidates": [],
+        "filtered_before_materialization": [
+          "lib/aaa_runtime.rb"
+        ]
+      },
+      "expected_fields": {
+        "boundary_evidence": {
+          "explicit_require_relative_load_suffixes": [
+            "lib/aaa_runtime.rb",
+            "lib/route_runtime.rb"
+          ],
+          "literal_dynamic_target_hints": [
+            "route_",
+            "route_created"
+          ]
+        },
+        "candidate_filtering": {
+          "generic_runtime": "none",
+          "route_runtime": {
+            "matched_call_line": 10,
+            "edge_certainty": "dynamic_fallback"
+          }
+        },
+        "cli_assertions": {
+          "impacted_files_excludes": [
+            "lib/aaa_runtime.rb"
+          ],
+          "selected_files_contains": [
+            "lib/route_runtime.rb"
+          ]
+        }
+      },
+      "regression_catch": [
+        "generic dynamic runtime noise survives into fallback candidates",
+        "literal target family hints disappear from boundary evidence",
+        "the intended route runtime is filtered out together with the noise"
       ]
     },
     {
@@ -243,7 +518,7 @@
       ],
       "failure_kind": "explanation_regression",
       "primary_view": "unit_test",
-      "focus": "selected-vs-pruned witness surface exposes winning evidence and winning support for a source_kind competition",
+      "focus": "selected-vs-pruned witness surface exposes winning evidence, winning support, and losing-side reason for a source_kind competition",
       "test_lanes": {
         "lib_unit": [
           "cargo",
@@ -252,14 +527,6 @@
           "selected_vs_pruned_reason_derives_winning_metadata_for_source_kind_explanations",
           "--",
           "--exact"
-        ]
-      },
-      "repro": {
-        "shape": [
-          "selected path lib/leaf.rb is graph_second_hop",
-          "pruned path lib/helper.rb is narrow_fallback",
-          "both compete through via_path lib/service.rb",
-          "selected has explicit_require_relative_load and stronger support metadata"
         ]
       },
       "expected_outcome": {
@@ -298,13 +565,15 @@
             "symbolic_propagation_support": true,
             "edge_certainty": "confirmed"
           },
-          "summary": "selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed"
+          "losing_side_reason": "fallback_only=narrow_fallback + edge_certainty=dynamic_fallback",
+          "summary": "selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed; losing side: fallback_only=narrow_fallback + edge_certainty=dynamic_fallback"
         }
       },
       "regression_catch": [
         "winning_primary_evidence_kinds stops reflecting selected-minus-pruned evidence",
         "winning_support drops support deltas such as symbolic_propagation_support or confirmed certainty",
-        "source-kind explanation degrades back to a bare ranking result without evidence/support detail"
+        "losing_side_reason drops fallback-only or dynamic_fallback metadata",
+        "source-kind explanation degrades back to a bare ranking result without evidence/support/losing-side detail"
       ]
     },
     {
@@ -362,19 +631,6 @@
           "--exact"
         ]
       },
-      "repro": {
-        "layout": [
-          "lib/leaf.rb",
-          "lib/zzz_helper.rb",
-          "lib/service.rb",
-          "app/runner.rb"
-        ],
-        "shape": [
-          "lib/service.rb require_relative loads both leaf.rb and zzz_helper.rb",
-          "bounce(value) calls finish(alias_value) and helper_noise(value)",
-          "app/runner.rb mutates prepared from seed + 1 to seed + 2"
-        ]
-      },
       "expected_outcome": {
         "selected_paths": [
           "app/runner.rb",
@@ -388,16 +644,7 @@
           }
         ],
         "selected_better_by": "lane",
-        "helper_excluded_from_explanation_slice": true,
-        "dot_assertions": {
-          "contains": [
-            "\"lib/leaf.rb:def:alias_value:2\"",
-            "\"app/runner.rb:use:prepared:5\" -> \"app/runner.rb:def:reply:5\""
-          ],
-          "excludes": [
-            "\"lib/zzz_helper.rb:def:debug_value:2\""
-          ]
-        }
+        "helper_excluded_from_explanation_slice": true
       },
       "expected_fields": {
         "selected_scoring": {

--- a/docs/g8-6-evidence-driven-eval-set.md
+++ b/docs/g8-6-evidence-driven-eval-set.md
@@ -1,17 +1,21 @@
 # G8-6: evidence-driven fixed evaluation set
 
-このメモは、G8 で入った evidence-driven selection / true narrow fallback / winning-evidence explanation を
-毎回戻って比較する **固定評価セット** を決めるためのもの。
+このメモは、G8 で入った evidence-driven selection / true narrow fallback / witness explanation を
+毎回戻って比較する **固定評価セット** を定義し、
+G9 で入った evidence conflict 系の改善をそこへ追加で固定するためのもの。
 
 G5/G7 までは主に bounded slice の広げ方と selected/pruned surface を固定していた。
-G8 でまず固定したいのは scope widening ではなく、
-**同じ bounded slice の中で何の evidence が勝敗を決め、どう explanation に出るか** である。
+G8 では scope widening ではなく、
+**同じ bounded slice の中で何の evidence が勝敗を決め、どう witness へ出るか** を固定した。
+G9 ではその続きとして、
+**negative / suppressing evidence、same-kind tie-break、dynamic fallback noise filter、losing-side reason**
+を固定評価セットへ足す。
 
-したがって G8-6 では、現在の HEAD にすでにある planner/unit/integration coverage のうち、
-evidence-driven 振る舞いを最も直接に固定できる 4 ケースを採用する。
+したがって現 HEAD の fixed set は、G8 の 4 ケースを維持しつつ、
+G9 で増えた evidence conflict ケースを追加した **7 ケース** で構成する。
 
-- Rust: 1 ケース
-- Ruby: 3 ケース
+- Rust: 3 ケース
+- Ruby: 4 ケース
 
 machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 
@@ -19,15 +23,21 @@ machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 
 ## 1. この評価セットで見るもの
 
-G8-6 で見たいのは、主に次の 4 種類。
+現行の fixed set で見たいのは主に次の 7 種類。
 
 1. **semantic evidence が positional noise に勝つこと**
    - `param_to_return_flow` が取れた Rust leaf が、後ろにある neutral helper を rank で押し切れるか
-2. **true narrow fallback が bounded に materialize されること**
-   - Ruby `method_missing` companion が graph-first へ滲まず、narrow fallback lane として選ばれるか
-3. **winner/pruned 差分が witness へそのまま出ること**
-   - `winning_primary_evidence_kinds` / `winning_support` / `summary` が selected/pruned 差分として安定しているか
-4. **CLI の selected/pruned witness surface が Ruby 競合ケースでも崩れないこと**
+2. **negative / suppressing evidence が noisy helper を落とすこと**
+   - return-ish helper noise が later callsite や lexical hint を持っていても selected されないか
+3. **same-kind 候補で semantic support の強さが tie-break になること**
+   - evidence kind 名が同じ Rust 候補同士でも、より強い semantic aggregation を持つ方が勝てるか
+4. **true narrow fallback が bounded に materialize されること**
+   - Ruby `method_missing` companion が graph-first へ滲まず narrow fallback lane として選ばれるか
+5. **dynamic-send 系の generic runtime noise が fallback candidate へ残らないこと**
+   - literal target family と関係のない generic runtime が filtering されるか
+6. **winner/pruned 差分と losing-side reason が witness へそのまま出ること**
+   - `winning_primary_evidence_kinds` / `winning_support` / `losing_side_reason` / `summary` が安定しているか
+7. **CLI の selected/pruned witness surface が Ruby 競合ケースでも崩れないこと**
    - selected file と ranked-out helper の分離、説明 slice、summary 文面が保たれるか
 
 ---
@@ -48,8 +58,9 @@ G8-6 で見たいのは、主に次の 4 種類。
 
 理由:
 
-- Rust competition と Ruby require_relative competition は CLI integration で固定済み
-- Ruby true narrow fallback と winning-evidence summary の最小面は、現 HEAD では planner/unit test が最も直接
+- Rust / Ruby の competition と filtering は CLI integration で固定するのが最も実態に近い
+- true narrow fallback の raw boundary/candidate evidence は planner unit が最も直接
+- witness explanation の最小面は `src/impact.rs` unit が最も直接
 
 ## 2.2 engine / format
 
@@ -59,7 +70,7 @@ G8-6 で見たいのは、主に次の 4 種類。
 
 ## 2.3 更新ルール
 
-この 4 ケースは G8 前半では入れ替えない。
+この 7 ケースは、現行 evidence conflict surface の fixed baseline として扱う。
 置換するなら、「より直接で、現 HEAD に既に存在する coverage へ置き換える理由」を別メモに残す。
 
 ---
@@ -69,8 +80,11 @@ G8-6 で見たいのは、主に次の 4 種類。
 | case_id | lang | kind | primary view | ねらい |
 | --- | --- | --- | --- | --- |
 | rust-param-to-return-flow-competition | rust | rank regression | dot + json + unit | `param_to_return_flow` が later helper noise に勝つ Rust Tier 2 competition |
+| rust-returnish-helper-negative-evidence | rust | suppressing regression | dot + json + unit | `noisy_return_hint` が later return-ish helper を ranked-out に留める |
+| rust-semantic-support-tiebreak | rust | tie-break regression | dot + json + unit | 同種 evidence の Rust 候補で `semantic_support_rank` が later callsite hint に勝つ |
 | ruby-method-missing-companion-narrow-fallback | ruby | narrow fallback FN | planner unit | `method_missing` companion を true narrow fallback lane で選ぶ Tier 3 case |
-| ruby-winning-evidence-source-kind-explanation | ruby | explanation regression | lib unit | selected/pruned の勝ち筋 evidence/support が witness summary に出る case |
+| ruby-dynamic-runtime-target-family-filter | ruby | fallback noise filter | json + planner unit | generic dynamic runtime noise を literal target family hint で事前 filtering する |
+| ruby-winning-evidence-source-kind-explanation | ruby | explanation regression | lib unit | selected/pruned の勝ち筋 evidence/support と losing-side reason が witness summary に出る |
 | ruby-require-relative-leaf-competition | ruby | rank regression | dot + json | selected/pruned witness surface を CLI で固定する require_relative competition |
 
 ---
@@ -86,17 +100,6 @@ G8-6 で見たいのは、主に次の 4 種類。
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper`
 - `src/bin/dimpact.rs::collect_rust_tier2_semantic_evidence_detects_param_to_return_flow`
 
-### Fixture / repro shape
-
-- `step.rs`
-  - `input -> forwarded -> return` の param passthrough leaf
-- `later.rs`
-  - 同じ wrapper から呼ばれる neutral helper noise
-- `wrapper.rs`
-  - `step::step(a)` と `later::later(a)` を両方呼ぶ
-- `main.rs`
-  - `input = 1 -> 2` の diff
-
 ### Fixed lane
 
 - CLI:
@@ -110,10 +113,10 @@ G8-6 で見たいのは、主に次の 4 種類。
 
 - selected files は `main.rs`, `step.rs`, `wrapper.rs`
 - `later.rs` は `pruned_candidates[*].prune_reason = ranked_out`
-- `step.rs` は `via_symbol_id = rust:wrapper.rs:fn:wrap:4` の Tier 2 bridge completion
+- selected は Tier 2 `bridge_completion_file` / `via_symbol_id = rust:wrapper.rs:fn:wrap:4`
 - witness では `rust:step.rs:fn:step:1` 側に selected-vs-pruned explanation が付く
 
-### Expected evidence / support / explanation fields
+### Expected fields
 
 - selected scoring:
   - `source_kind = graph_second_hop`
@@ -139,7 +142,107 @@ G8-6 で見たいのは、主に次の 4 種類。
 
 ---
 
-## 4.2 `ruby-method-missing-companion-narrow-fallback`
+## 4.2 `rust-returnish-helper-negative-evidence`
+
+### Source
+
+- `src/bin/dimpact.rs::bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion`
+- `tests/cli_pdg_propagation.rs::setup_cross_file_returnish_helper_noise_repo`
+- `tests/cli_pdg_propagation.rs::pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite`
+- `src/impact.rs::selected_vs_pruned_reason_derives_losing_side_reason_from_negative_evidence`
+
+### Fixed lane
+
+- CLI:
+  - `impact --direction callees --with-pdg --format dot`
+  - `impact --direction callees --with-propagation --format json`
+- test:
+  - `cargo test --bin dimpact bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion -- --exact`
+  - `cargo test --test cli_pdg_propagation pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite -- --exact`
+
+### Locked outcome
+
+- selected files は `leaf.rs`, `main.rs`, `wrapper.rs`
+- `zzz_final_helper.rs` は `ranked_out`
+- selected/pruned は両方 `wrapper_return` competition だが、helper 側だけ `negative_evidence_kinds = [noisy_return_hint]` を持つ
+- witness では compact な losing-side reason が出る
+
+### Expected fields
+
+- selected scoring (`leaf.rs`):
+  - `source_kind = graph_second_hop`
+  - `lane = return_continuation`
+  - `primary_evidence_kinds = [assigned_result, return_flow]`
+  - `secondary_evidence_kinds = [name_path_hint]`
+- pruned scoring (`zzz_final_helper.rs`):
+  - `primary_evidence_kinds = [assigned_result, return_flow]`
+  - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
+  - `negative_evidence_kinds = [noisy_return_hint]`
+  - `score_tuple.negative_evidence_count = 1`
+- witness reason:
+  - `selected_better_by = negative_evidence_count`
+  - `losing_side_reason = negative_evidence=noisy_return_hint`
+  - summary:
+    - `selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint`
+
+### Regression to catch
+
+- later return-ish helper が call position や lexical hint で再び勝つ
+- `negative_evidence_kinds` が pruned metadata から落ちる
+- losing-side reason が witness summary から消える
+
+---
+
+## 4.3 `rust-semantic-support-tiebreak`
+
+### Source
+
+- `src/bin/dimpact.rs::bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint`
+- `tests/cli_pdg_propagation.rs::setup_cross_file_semantic_support_competition_repo`
+- `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint`
+
+### Fixed lane
+
+- CLI:
+  - `impact --direction callees --with-pdg --format dot`
+  - `impact --direction callees --with-propagation --format json`
+- test:
+  - `cargo test --bin dimpact bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact`
+  - `cargo test --test cli_pdg_propagation pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact`
+
+### Locked outcome
+
+- selected files は `main.rs`, `steady.rs`, `wrapper.rs`
+- `plain.rs` は `ranked_out`
+- selected/pruned は両方 `return_continuation` かつ `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
+- tie-break は `secondary_evidence_count` や `call_position_rank` より前に `semantic_support_rank` で決まる
+
+### Expected fields
+
+- selected scoring (`steady.rs`):
+  - `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
+  - `secondary_evidence_kinds = [name_path_hint]`
+  - `score_tuple.semantic_support_rank = 3`
+  - `support.local_dfg_support = true`
+- pruned scoring (`plain.rs`):
+  - `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
+  - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
+  - `score_tuple.semantic_support_rank = 2`
+  - `support.local_dfg_support = true`
+- witness reason:
+  - `selected_better_by = semantic_support_rank`
+  - summary:
+    - `selected over plain.rs because it had stronger semantic support (3 > 2)`
+
+### Regression to catch
+
+- same-kind 候補が再び later callsite hint だけで決まる
+- `semantic_support_rank` が score tuple から落ちる
+- stronger semantic leaf が `plain.rs` に押し負ける
+
+---
+
+## 4.4 `ruby-method-missing-companion-narrow-fallback`
 
 ### Source
 
@@ -147,19 +250,6 @@ G8-6 で見たいのは、主に次の 4 種類。
 - `docs/g8-2-bridge-scoring-evidence-schema.json`
 - `src/bin/dimpact.rs::bounded_slice_plan_selects_ruby_method_missing_companion_as_narrow_fallback`
 - `tests/fixtures/ruby/analyzer_hard_cases_dynamic_dsl_method_missing_chain_v4.rb`
-
-### Fixture / repro shape
-
-planner unit test が temp repo を組み立てる。
-
-- `app/main.rb`
-  - `Router.new.run_created("alpha")`
-- `lib/router.rb`
-  - `require_relative "runtime"`
-  - `@runtime.public_send("route_created", payload)`
-- `lib/runtime.rb`
-  - `RuntimeProxy#method_missing`
-  - `respond_to_missing?`
 
 ### Fixed lane
 
@@ -174,7 +264,7 @@ planner unit test が temp repo を組み立てる。
 - `cache_update_paths` は temp repo 上の `app/main.rb`, `lib/router.rb`, `lib/runtime.rb`
 - `pruned_candidates` は空
 
-### Expected evidence / support / explanation fields
+### Expected fields
 
 - boundary evidence:
   - `explicit_require_relative_loads` は temp repo 上の `lib/runtime.rb` を含む
@@ -188,9 +278,6 @@ planner unit test が temp repo を組み立てる。
   - `primary_evidence_kinds = [companion_file_match, dynamic_dispatch_literal_target, explicit_require_relative_load]`
   - `secondary_evidence_kinds = []`
   - `support.edge_certainty = dynamic_fallback`
-- explanation surface:
-  - selected/pruned explanation は不要
-  - `pruned_candidates = []` のまま narrow fallback 単独選択で終わる
 
 ### Regression to catch
 
@@ -200,28 +287,56 @@ planner unit test が temp repo を組み立てる。
 
 ---
 
-## 4.3 `ruby-winning-evidence-source-kind-explanation`
+## 4.5 `ruby-dynamic-runtime-target-family-filter`
+
+### Source
+
+- `src/bin/dimpact.rs::ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint`
+- `tests/cli_pdg_propagation.rs::setup_ruby_dynamic_send_runtime_noise_repo`
+- `tests/cli_pdg_propagation.rs::pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise`
+
+### Fixed lane
+
+- CLI:
+  - `impact --direction callees --lang ruby --with-propagation --format json`
+- test:
+  - `cargo test --bin dimpact ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint -- --exact`
+  - `cargo test --test cli_pdg_propagation pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise -- --exact`
+
+### Locked outcome
+
+- selected files は `app/runner.rb`, `lib/route_runtime.rb`, `lib/service.rb`
+- `pruned_candidates = []`
+- `lib/aaa_runtime.rb` は candidate materialization 前に filtering される
+- family-specific runtime だけが `via_path = lib/service.rb` を通って残る
+
+### Expected fields
+
+- boundary evidence:
+  - `explicit_require_relative_loads` は `lib/aaa_runtime.rb`, `lib/route_runtime.rb` を両方含む
+  - `literal_dynamic_target_hints = [route_, route_created]`
+- candidate filtering:
+  - `collect_ruby_narrow_fallback_candidate_evidence(lib/aaa_runtime.rb, ...) = None`
+  - `collect_ruby_narrow_fallback_candidate_evidence(lib/route_runtime.rb, ...)` は `matched_call_line = 10` / `edge_certainty = dynamic_fallback`
+- CLI outcome:
+  - `lib/aaa_runtime.rb` は `impacted_files` に入らない
+  - `lib/route_runtime.rb` は selected file に残る
+
+### Regression to catch
+
+- generic dynamic runtime noise が再び fallback candidate へ残る
+- literal target family hint が boundary evidence から落ちる
+- intended runtime (`route_runtime.rb`) まで filtering される
+
+---
+
+## 4.6 `ruby-winning-evidence-source-kind-explanation`
 
 ### Source
 
 - `docs/g8-1-missing-evidence-inventory-and-design-memo.md`
 - `docs/g8-2-bridge-scoring-evidence-schema.json`
 - `src/impact.rs::selected_vs_pruned_reason_derives_winning_metadata_for_source_kind_explanations`
-
-### Fixture / repro shape
-
-`build_selected_vs_pruned_reasons()` を直接叩く unit case。
-
-- selected path: `lib/leaf.rb`
-- pruned path: `lib/helper.rb`
-- `via_path = lib/service.rb`
-- selected scoring:
-  - `source_kind = graph_second_hop`
-  - `lane = module_companion_fallback`
-  - primary evidence は `companion_file_match + explicit_require_relative_load`
-- pruned scoring:
-  - `source_kind = narrow_fallback`
-  - primary evidence は `companion_file_match` のみ
 
 ### Fixed lane
 
@@ -234,7 +349,7 @@ planner unit test が temp repo を組み立てる。
 - pruned は `lib/helper.rb`
 - `selected_better_by = source_kind`
 
-### Expected evidence / support / explanation fields
+### Expected fields
 
 - selected scoring support:
   - `symbolic_propagation_support = true`
@@ -245,36 +360,25 @@ planner unit test が temp repo を組み立てる。
   - `winning_primary_evidence_kinds = [explicit_require_relative_load]`
   - `winning_support.symbolic_propagation_support = true`
   - `winning_support.edge_certainty = confirmed`
+  - `losing_side_reason = fallback_only=narrow_fallback + edge_certainty=dynamic_fallback`
   - summary:
-    - `selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed`
+    - `selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed; losing side: fallback_only=narrow_fallback + edge_certainty=dynamic_fallback`
 
 ### Regression to catch
 
 - `winning_primary_evidence_kinds` が selected/pruned 差分から導けなくなる
 - `winning_support` が support 差分を落とす
-- source-kind 勝敗の summary が evidence/support なしの薄い文面へ戻る
+- `losing_side_reason` が fallback-only / dynamic_fallback を落とす
+- source-kind 勝敗の summary が evidence/support/losing-side なしの薄い文面へ戻る
 
 ---
 
-## 4.4 `ruby-require-relative-leaf-competition`
+## 4.7 `ruby-require-relative-leaf-competition`
 
 ### Source
 
 - `tests/cli_pdg_propagation.rs::setup_ruby_require_relative_competing_leaf_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise`
-
-### Fixture / repro shape
-
-- `lib/leaf.rb`
-  - `alias_value = value; return alias_value`
-- `lib/zzz_helper.rb`
-  - later helper noise
-- `lib/service.rb`
-  - `require_relative 'leaf'`
-  - `require_relative 'zzz_helper'`
-  - `wrapped = finish(alias_value)` と `helper_noise(value)` の競合
-- `app/runner.rb`
-  - `prepared = seed + 1 -> seed + 2` の diff
 
 ### Fixed lane
 
@@ -292,7 +396,7 @@ planner unit test が temp repo を組み立てる。
 - helper witness の `selected_files_on_path` には `lib/zzz_helper.rb` が入らない
 - propagation dot では `app/runner.rb:use:prepared:5 -> app/runner.rb:def:reply:5` の bridge が出る
 
-### Expected evidence / support / explanation fields
+### Expected fields
 
 - selected scoring (`lib/leaf.rb`):
   - `source_kind = graph_second_hop`
@@ -315,3 +419,19 @@ planner unit test が temp repo を組み立てる。
 - helper noise が lane/position で勝って `lib/leaf.rb` を押しのける
 - ranked-out helper が explanation slice に混ざる
 - Ruby CLI witness surface から winning evidence の summary が落ちる
+
+---
+
+## 5. この set が G9 で追加で守るもの
+
+G8 時点の fixed set は「改善が効いたこと」を押さえるには十分だったが、
+evidence conflict の正規化面はまだ薄かった。
+現行の 7 ケースでは、少なくとも次が固定される。
+
+- `negative_evidence_kinds` が noisy helper suppression と witness summary の両方へ出ること
+- `semantic_support_rank` が same-kind Rust competition の compare order に入ること
+- Ruby true narrow fallback が literal dynamic target family によって bounded に絞られること
+- witness が winning-side だけでなく losing-side の簡易理由も持てること
+
+これにより、G9-3〜G9-6 で入った evidence conflict surface が
+固定評価セットの上でも regression 監視できるようになる。


### PR DESCRIPTION
## Summary
- extend the fixed G8 evidence-driven eval set with G9 evidence-conflict cases for negative evidence, same-kind semantic tie-breaks, and Ruby dynamic runtime filtering
- update the witness explanation case to lock the new losing-side reason surface alongside winning evidence/support
- refresh the machine-readable eval-set companion so the new cases and expected fields are tracked in one place

## Testing
- git diff --check
- python3 -m json.tool docs/g8-6-evidence-driven-eval-set.json >/dev/null
- cargo test --offline --bin dimpact bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion -- --exact
- cargo test --offline --bin dimpact bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact
- cargo test --offline --bin dimpact ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint -- --exact
- cargo test --offline --lib selected_vs_pruned_reason_derives_winning_metadata_for_source_kind_explanations -- --exact
- cargo test --offline --test cli_pdg_propagation pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite -- --exact
- cargo test --offline --test cli_pdg_propagation pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact
- cargo test --offline --test cli_pdg_propagation pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise -- --exact