### PR TITLE
Suppress weaker Rust sibling candidates

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -2042,6 +2042,80 @@ fn suppress_before_admit(
     admitted
 }
 
+fn rust_same_family_sibling_lane(candidate: &Tier2Candidate) -> Option<ImpactSliceCandidateLane> {
+    (candidate.scoring.source_kind == ImpactSliceCandidateSourceKind::GraphSecondHop
+        && candidate.path.ends_with(".rs")
+        && candidate.via_path.ends_with(".rs")
+        && matches!(
+            candidate.scoring.lane,
+            ImpactSliceCandidateLane::ReturnContinuation
+                | ImpactSliceCandidateLane::AliasContinuation
+        ))
+    .then_some(candidate.scoring.lane)
+}
+
+fn candidate_has_rust_semantic_support(candidate: &Tier2Candidate) -> bool {
+    candidate.scoring.score_tuple.semantic_support_rank > 0
+}
+
+fn suppress_weaker_same_family_rust_siblings(
+    seed_symbol_id: &str,
+    seed_selection: &mut SliceSelectionAccumulator,
+    side_candidates: Vec<Tier2Candidate>,
+) -> Vec<Tier2Candidate> {
+    let mut strongest_semantic_ready_by_lane = std::collections::BTreeMap::new();
+    for candidate in &side_candidates {
+        let Some(lane) = rust_same_family_sibling_lane(candidate) else {
+            continue;
+        };
+        if !candidate_has_rust_semantic_support(candidate) {
+            continue;
+        }
+
+        match strongest_semantic_ready_by_lane.entry(lane) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(candidate.clone());
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                if compare_tier2_candidates(candidate, entry.get()).is_lt() {
+                    entry.insert(candidate.clone());
+                }
+            }
+        }
+    }
+
+    if strongest_semantic_ready_by_lane.is_empty() {
+        return side_candidates;
+    }
+
+    let mut admitted = Vec::new();
+    for candidate in side_candidates {
+        let Some(lane) = rust_same_family_sibling_lane(&candidate) else {
+            admitted.push(candidate);
+            continue;
+        };
+        let Some(stronger_candidate) = strongest_semantic_ready_by_lane.get(&lane) else {
+            admitted.push(candidate);
+            continue;
+        };
+        if candidate_has_rust_semantic_support(&candidate)
+            || stronger_candidate == &candidate
+            || !compare_tier2_candidates(stronger_candidate, &candidate).is_lt()
+        {
+            admitted.push(candidate);
+            continue;
+        }
+
+        seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+            seed_symbol_id,
+            &candidate,
+            ImpactSlicePruneReason::WeakerSameFamilySibling,
+        ));
+    }
+
+    admitted
+}
+
 fn plan_bounded_slice(
     cache_update_roots: &[String],
     local_dfg_roots: &[String],
@@ -2208,10 +2282,15 @@ fn plan_bounded_slice(
                 );
             }
 
-            let mut side_candidates = suppress_before_admit(
+            let side_candidates = suppress_before_admit(
                 seed.id.0.as_str(),
                 &mut seed_selection,
                 side_candidates.into_values().collect(),
+            );
+            let mut side_candidates = suppress_weaker_same_family_rust_siblings(
+                seed.id.0.as_str(),
+                &mut seed_selection,
+                side_candidates,
             );
             side_candidates.sort_by(compare_tier2_candidates);
             for candidate in side_candidates
@@ -4125,7 +4204,7 @@ fn caller() -> i32 {
                 .iter()
                 .any(|candidate| {
                     candidate.path == "later.rs"
-                        && candidate.prune_reason == ImpactSlicePruneReason::RankedOut
+                        && candidate.prune_reason == ImpactSlicePruneReason::WeakerSameFamilySibling
                         && candidate.bridge_kind == Some(ImpactSliceBridgeKind::WrapperReturn)
                         && candidate.via_symbol_id.as_deref() == Some("rust:wrapper.rs:fn:wrap:4")
                         && candidate.scoring.as_ref().is_some_and(|scoring| {
@@ -4142,7 +4221,7 @@ fn caller() -> i32 {
                                     ]
                         })
                 }),
-            "expected later neutral helper to be ranked out once param-to-return evidence is available: {:#?}",
+            "expected later neutral helper to be pruned as a weaker same-family sibling once param-to-return evidence is available: {:#?}",
             plan.slice_selection.pruned_candidates
         );
     }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -263,6 +263,7 @@ pub enum ImpactSlicePruneReason {
     LocalDfgBudgetExhausted,
     SuppressedBeforeAdmit,
     WeakerSamePathDuplicate,
+    WeakerSameFamilySibling,
     RankedOut,
 }
 
@@ -1086,7 +1087,9 @@ fn selected_reason_matches_pruned_candidate(
     reason.kind == ImpactSliceReasonKind::BridgeCompletionFile
         && matches!(
             candidate.prune_reason,
-            ImpactSlicePruneReason::RankedOut | ImpactSlicePruneReason::SuppressedBeforeAdmit
+            ImpactSlicePruneReason::RankedOut
+                | ImpactSlicePruneReason::SuppressedBeforeAdmit
+                | ImpactSlicePruneReason::WeakerSameFamilySibling
         )
         && candidate.path != selected_path
         && reason.seed_symbol_id == candidate.seed_symbol_id
@@ -3191,6 +3194,104 @@ fn foo() { bar(); }
                 winning_support: None,
                 losing_side_reason: Some("negative_evidence=noisy_return_hint".to_string()),
                 summary: "selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn selected_vs_pruned_reason_matches_weaker_same_family_sibling_prune_reason() {
+        let seed_symbol_id = "rust:main.rs:fn:caller:1".to_string();
+        let via_symbol_id = "rust:wrapper.rs:fn:wrap:4".to_string();
+        let reasons = build_selected_vs_pruned_reasons(
+            "step.rs",
+            &[ImpactSliceReasonMetadata {
+                seed_symbol_id: seed_symbol_id.clone(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some(via_symbol_id.clone()),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ParamToReturnFlow,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 3,
+                        secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 2,
+                        call_position_rank: 5,
+                        lexical_tiebreak: "step.rs".to_string(),
+                    },
+                    support: Some(ImpactSliceCandidateSupportMetadata {
+                        local_dfg_support: true,
+                        ..ImpactSliceCandidateSupportMetadata::default()
+                    }),
+                }),
+            }],
+            &[ImpactSlicePrunedCandidate {
+                seed_symbol_id,
+                path: "later.rs".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some(via_symbol_id),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                prune_reason: ImpactSlicePruneReason::WeakerSameFamilySibling,
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    secondary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::CallsitePositionHint,
+                        ImpactSliceEvidenceKind::NamePathHint,
+                    ],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 2,
+                        secondary_evidence_count: 2,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 6,
+                        lexical_tiebreak: "later.rs".to_string(),
+                    },
+                    support: None,
+                }),
+            }],
+        );
+
+        assert_eq!(
+            reasons,
+            vec![ImpactWitnessSliceSelectedVsPrunedReason {
+                via_symbol_id: Some("rust:wrapper.rs:fn:wrap:4".to_string()),
+                via_path: Some("wrapper.rs".to_string()),
+                selected_bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                pruned_path: "later.rs".to_string(),
+                prune_reason: ImpactSlicePruneReason::WeakerSameFamilySibling,
+                pruned_bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                selected_better_by: ImpactWitnessSliceRankingBasis::PrimaryEvidenceCount,
+                winning_primary_evidence_kinds: Some(vec![
+                    ImpactSliceEvidenceKind::ParamToReturnFlow,
+                ]),
+                winning_support: Some(ImpactSliceCandidateSupportMetadata {
+                    local_dfg_support: true,
+                    ..ImpactSliceCandidateSupportMetadata::default()
+                }),
+                losing_side_reason: None,
+                summary: "selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support".to_string(),
             }]
         );
     }

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1932,7 +1932,7 @@ fn pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper(
             .as_array()
             .is_some_and(|candidates| candidates.iter().any(|candidate| {
                 candidate["path"] == "later.rs"
-                    && candidate["prune_reason"] == "ranked_out"
+                    && candidate["prune_reason"] == "weaker_same_family_sibling"
                     && candidate["via_symbol_id"] == "rust:wrapper.rs:fn:wrap:4"
                     && candidate["bridge_kind"] == "wrapper_return"
                     && candidate["scoring"]
@@ -1957,7 +1957,7 @@ fn pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper(
                             }
                         })
             })),
-        "expected later.rs to remain only as ranked-out metadata once param flow is observed: {prop:#}"
+        "expected later.rs to remain only as weaker same-family sibling metadata once param flow is observed: {prop:#}"
     );
 
     let witness = &prop["impacted_witnesses"]["rust:step.rs:fn:step:1"];
@@ -1969,7 +1969,7 @@ fn pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper(
             "via_path": "wrapper.rs",
             "selected_bridge_kind": "wrapper_return",
             "pruned_path": "later.rs",
-            "prune_reason": "ranked_out",
+            "prune_reason": "weaker_same_family_sibling",
             "pruned_bridge_kind": "wrapper_return",
             "selected_better_by": "primary_evidence_count",
             "winning_primary_evidence_kinds": [


### PR DESCRIPTION
## Summary
- add a Rust-side same-family sibling suppression pass before side-local ranking in the bounded slice planner
- record weaker Rust return/alias siblings with an explicit `weaker_same_family_sibling` prune reason and keep witness matching working
- update the param-passthrough vs later helper planner/CLI regressions to assert the new early-prune behavior

## Testing
- cargo test --offline
- cargo clippy --offline