### PR TITLE
Add compact dropped-before-admit explanations

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -2032,6 +2032,25 @@ fn make_tier2_pruned_candidate(
     candidate: &Tier2Candidate,
     prune_reason: ImpactSlicePruneReason,
 ) -> dimpact::ImpactSlicePrunedCandidate {
+    let compact_explanation = match prune_reason {
+        ImpactSlicePruneReason::SuppressedBeforeAdmit => {
+            let suppressor = if candidate_is_weak_ruby_require_relative(candidate) {
+                Some("fallback_only_suppressor")
+            } else if candidate_has_helper_noise_signal(candidate)
+                && candidate_is_lexical_or_callsite_only(candidate)
+            {
+                Some("helper_noise_suppressor")
+            } else {
+                None
+            };
+            suppressor.map(|label| format!("suppressed_before_admit={label}"))
+        }
+        ImpactSlicePruneReason::WeakerSamePathDuplicate => {
+            Some("suppressed_before_admit=weaker_same_path_duplicate".to_string())
+        }
+        _ => None,
+    };
+
     dimpact::ImpactSlicePrunedCandidate {
         seed_symbol_id: seed_symbol_id.to_string(),
         path: candidate.path.clone(),
@@ -2042,6 +2061,7 @@ fn make_tier2_pruned_candidate(
         bridge_kind: candidate.bridge_kind,
         prune_reason,
         scoring: Some(candidate.scoring.clone()),
+        compact_explanation,
     }
 }
 
@@ -3921,6 +3941,8 @@ fn caller() -> i32 {
                 .any(|candidate| {
                     candidate.path == "aaa_helper.rs"
                         && candidate.prune_reason == ImpactSlicePruneReason::SuppressedBeforeAdmit
+                        && candidate.compact_explanation.as_deref()
+                            == Some("suppressed_before_admit=helper_noise_suppressor")
                         && candidate.bridge_kind
                             == Some(ImpactSliceBridgeKind::BoundaryAliasContinuation)
                         && candidate.via_symbol_id.as_deref() == Some("rust:wrapper.rs:fn:wrap:3")
@@ -4034,6 +4056,7 @@ fn caller() -> i32 {
                     },
                     support: None,
                 }),
+                compact_explanation: None,
             }]
         );
     }
@@ -4104,6 +4127,8 @@ fn caller() -> i32 {
                 .any(|candidate| {
                     candidate.path == "zzz_helper.rs"
                         && candidate.prune_reason == ImpactSlicePruneReason::SuppressedBeforeAdmit
+                        && candidate.compact_explanation.as_deref()
+                            == Some("suppressed_before_admit=helper_noise_suppressor")
                         && candidate.bridge_kind
                             == Some(ImpactSliceBridgeKind::BoundaryAliasContinuation)
                         && candidate.via_symbol_id.as_deref() == Some("rust:adapter.rs:fn:wrap:3")
@@ -4464,6 +4489,7 @@ fn caller() -> i32 {
                         ..ImpactSliceCandidateSupportMetadata::default()
                     }),
                 }),
+                compact_explanation: None,
             }]
         );
     }
@@ -4581,6 +4607,9 @@ fn caller() -> i32 {
                     7,
                     "lib/zzz_helper.rb",
                 )),
+                compact_explanation: Some(
+                    "suppressed_before_admit=fallback_only_suppressor".to_string(),
+                ),
             }],
             "expected later Ruby helper noise to be suppressed before side ranking: {:#?}",
             plan.slice_selection.pruned_candidates
@@ -4663,6 +4692,9 @@ fn caller() -> i32 {
                     6,
                     "shared.rs",
                 )),
+                compact_explanation: Some(
+                    "suppressed_before_admit=weaker_same_path_duplicate".to_string(),
+                ),
             }]
         );
     }
@@ -4767,6 +4799,9 @@ fn caller() -> i32 {
                     7,
                     "lib/runtime.rb",
                 )),
+                compact_explanation: Some(
+                    "suppressed_before_admit=fallback_only_suppressor".to_string(),
+                ),
             }]
         );
     }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -252,6 +252,8 @@ pub struct ImpactSlicePrunedCandidate {
     pub prune_reason: ImpactSlicePruneReason,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scoring: Option<ImpactSliceCandidateScoringSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_explanation: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -356,6 +358,8 @@ pub struct ImpactWitnessSliceSelectedVsPrunedReason {
     pub winning_support: Option<ImpactSliceCandidateSupportMetadata>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub losing_side_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_explanation: Option<String>,
     pub summary: String,
 }
 
@@ -809,9 +813,7 @@ fn selected_vs_pruned_winning_support(
     selected: &ImpactSliceCandidateScoringSummary,
     pruned: &ImpactSliceCandidateScoringSummary,
 ) -> Option<ImpactSliceCandidateSupportMetadata> {
-    let Some(selected_support) = selected.support.as_ref() else {
-        return None;
-    };
+    let selected_support = selected.support.as_ref()?;
     let pruned_support = pruned.support.as_ref();
     let winning_support = ImpactSliceCandidateSupportMetadata {
         call_graph_support: selected_support.call_graph_support
@@ -864,6 +866,7 @@ fn selected_vs_pruned_summary_support_labels(
     labels
 }
 
+#[allow(clippy::too_many_arguments)]
 fn selected_vs_pruned_summary(
     selected_path: &str,
     pruned_path: &str,
@@ -1139,6 +1142,7 @@ fn build_selected_vs_pruned_reasons(
                 winning_primary_evidence_kinds: winning_primary_evidence_kinds.clone(),
                 winning_support: winning_support.clone(),
                 losing_side_reason: losing_side_reason.clone(),
+                compact_explanation: candidate.compact_explanation.clone(),
                 summary: selected_vs_pruned_summary(
                     selected_path,
                     &candidate.path,
@@ -2957,6 +2961,7 @@ fn foo() { bar(); }
                     },
                     support: None,
                 }),
+                compact_explanation: None,
             }],
         };
 
@@ -2990,6 +2995,7 @@ fn foo() { bar(); }
                 winning_primary_evidence_kinds: Some(vec![ImpactSliceEvidenceKind::ReturnFlow]),
                 winning_support: None,
                 losing_side_reason: None,
+                compact_explanation: None,
                 summary: "selected over aaa_helper.rs because return_continuation outranked alias_continuation; winning primary evidence: return_flow".to_string(),
             }]
         );
@@ -3079,6 +3085,7 @@ fn foo() { bar(); }
                         ..ImpactSliceCandidateSupportMetadata::default()
                     }),
                 }),
+                compact_explanation: None,
             }],
         );
 
@@ -3104,7 +3111,97 @@ fn foo() { bar(); }
                     "fallback_only=narrow_fallback + edge_certainty=dynamic_fallback"
                         .to_string()
                 ),
+                compact_explanation: None,
                 summary: "selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed; losing side: fallback_only=narrow_fallback + edge_certainty=dynamic_fallback".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn selected_vs_pruned_reason_carries_compact_explanation_for_suppressed_before_admit() {
+        let seed_symbol_id = "rust:main.rs:fn:caller:1".to_string();
+        let via_symbol_id = "rust:wrapper.rs:fn:wrap:4".to_string();
+        let reasons = build_selected_vs_pruned_reasons(
+            "leaf.rs",
+            &[ImpactSliceReasonMetadata {
+                seed_symbol_id: seed_symbol_id.clone(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some(via_symbol_id.clone()),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 2,
+                        secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 5,
+                        lexical_tiebreak: "leaf.rs".to_string(),
+                    },
+                    support: None,
+                }),
+            }],
+            &[ImpactSlicePrunedCandidate {
+                seed_symbol_id,
+                path: "aaa_helper.rs".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some(via_symbol_id),
+                via_path: Some("wrapper.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                prune_reason: ImpactSlicePruneReason::SuppressedBeforeAdmit,
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::AliasContinuation,
+                    primary_evidence_kinds: vec![ImpactSliceEvidenceKind::AssignedResult],
+                    secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 1,
+                        primary_evidence_count: 1,
+                        secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 4,
+                        lexical_tiebreak: "aaa_helper.rs".to_string(),
+                    },
+                    support: None,
+                }),
+                compact_explanation: Some(
+                    "suppressed_before_admit=helper_noise_suppressor".to_string(),
+                ),
+            }],
+        );
+
+        assert_eq!(
+            reasons,
+            vec![ImpactWitnessSliceSelectedVsPrunedReason {
+                via_symbol_id: Some("rust:wrapper.rs:fn:wrap:4".to_string()),
+                via_path: Some("wrapper.rs".to_string()),
+                selected_bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                pruned_path: "aaa_helper.rs".to_string(),
+                prune_reason: ImpactSlicePruneReason::SuppressedBeforeAdmit,
+                pruned_bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                selected_better_by: ImpactWitnessSliceRankingBasis::Lane,
+                winning_primary_evidence_kinds: Some(vec![ImpactSliceEvidenceKind::ReturnFlow]),
+                winning_support: None,
+                losing_side_reason: None,
+                compact_explanation: Some(
+                    "suppressed_before_admit=helper_noise_suppressor".to_string(),
+                ),
+                summary: "selected over aaa_helper.rs because return_continuation outranked alias_continuation; winning primary evidence: return_flow".to_string(),
             }]
         );
     }
@@ -3177,6 +3274,7 @@ fn foo() { bar(); }
                     },
                     support: None,
                 }),
+                compact_explanation: None,
             }],
         );
 
@@ -3193,6 +3291,7 @@ fn foo() { bar(); }
                 winning_primary_evidence_kinds: None,
                 winning_support: None,
                 losing_side_reason: Some("negative_evidence=noisy_return_hint".to_string()),
+                compact_explanation: None,
                 summary: "selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint".to_string(),
             }]
         );
@@ -3270,6 +3369,7 @@ fn foo() { bar(); }
                     },
                     support: None,
                 }),
+                compact_explanation: None,
             }],
         );
 
@@ -3291,6 +3391,7 @@ fn foo() { bar(); }
                     ..ImpactSliceCandidateSupportMetadata::default()
                 }),
                 losing_side_reason: None,
+                compact_explanation: None,
                 summary: "selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support".to_string(),
             }]
         );
@@ -3309,6 +3410,7 @@ fn foo() { bar(); }
             winning_primary_evidence_kinds: None,
             winning_support: None,
             losing_side_reason: None,
+            compact_explanation: None,
             summary:
                 "selected over helper.rs because return_continuation outranked alias_continuation"
                     .to_string(),
@@ -3318,6 +3420,7 @@ fn foo() { bar(); }
         assert!(value.get("winning_primary_evidence_kinds").is_none());
         assert!(value.get("winning_support").is_none());
         assert!(value.get("losing_side_reason").is_none());
+        assert!(value.get("compact_explanation").is_none());
     }
 
     #[test]

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1513,6 +1513,8 @@ fn pdg_slice_selection_prefers_wrapper_return_leaf_over_earlier_noise_candidate(
             .is_some_and(|candidates| candidates.iter().any(|candidate| {
                 candidate["path"] == "aaa_helper.rs"
                     && candidate["prune_reason"] == "suppressed_before_admit"
+                    && candidate["compact_explanation"]
+                        == "suppressed_before_admit=helper_noise_suppressor"
                     && candidate["via_symbol_id"] == "rust:wrapper.rs:fn:wrap:4"
                     && candidate["bridge_kind"] == "boundary_alias_continuation"
                     && candidate["scoring"]
@@ -1552,6 +1554,7 @@ fn pdg_slice_selection_prefers_wrapper_return_leaf_over_earlier_noise_candidate(
             "winning_primary_evidence_kinds": [
                 "return_flow"
             ],
+            "compact_explanation": "suppressed_before_admit=helper_noise_suppressor",
             "summary": "selected over aaa_helper.rs because return_continuation outranked alias_continuation; winning primary evidence: return_flow",
         }])
     );
@@ -1793,6 +1796,8 @@ fn pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helpe
             .is_some_and(|candidates| candidates.iter().any(|candidate| {
                 candidate["path"] == "zzz_helper.rs"
                     && candidate["prune_reason"] == "suppressed_before_admit"
+                    && candidate["compact_explanation"]
+                        == "suppressed_before_admit=helper_noise_suppressor"
                     && candidate["via_symbol_id"] == "rust:adapter.rs:fn:wrap:4"
                     && candidate["bridge_kind"] == "boundary_alias_continuation"
                     && candidate["scoring"]
@@ -1834,6 +1839,7 @@ fn pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helpe
             "winning_primary_evidence_kinds": [
                 "alias_chain"
             ],
+            "compact_explanation": "suppressed_before_admit=helper_noise_suppressor",
             "summary": "selected over zzz_helper.rs because it had more primary evidence (2 > 1); winning primary evidence: alias_chain",
         }])
     );
@@ -2220,6 +2226,8 @@ fn pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_nois
             .is_some_and(|candidates| candidates.iter().any(|candidate| {
                 candidate["path"] == "lib/zzz_helper.rb"
                     && candidate["prune_reason"] == "suppressed_before_admit"
+                    && candidate["compact_explanation"]
+                        == "suppressed_before_admit=fallback_only_suppressor"
                     && candidate["via_symbol_id"] == "ruby:lib/service.rb:method:bounce:4"
                     && candidate["bridge_kind"] == "require_relative_chain"
                     && candidate["scoring"]
@@ -2260,6 +2268,7 @@ fn pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_nois
                 "assigned_result",
                 "return_flow"
             ],
+            "compact_explanation": "suppressed_before_admit=fallback_only_suppressor",
             "summary": "selected over lib/zzz_helper.rb because return_continuation outranked require_relative_continuation; winning primary evidence: assigned_result + return_flow",
         }])
     );
@@ -2330,6 +2339,8 @@ fn pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise() {
                     && candidates.iter().all(|candidate| {
                         candidate["path"] == "lib/route_runtime.rb"
                             && candidate["prune_reason"] == "weaker_same_path_duplicate"
+                            && candidate["compact_explanation"]
+                                == "suppressed_before_admit=weaker_same_path_duplicate"
                     })
             }),
         "expected generic runtime noise to stay filtered while same-path route_runtime losers are recorded explicitly: {prop:#}"
@@ -2679,21 +2690,15 @@ fn ruby_chain_fixture_only_gains_symbolic_edges_with_propagation() {
         "expected fixed pair of symbolic edges: {prop:#}"
     );
     assert!(prop_edges.iter().all(|e| e["kind"] == "data"));
-    assert!(
-        prop_edges
-            .iter()
-            .all(|e| e["provenance"] == "symbolic_propagation")
-    );
-    assert!(
-        prop_edges
-            .iter()
-            .any(|e| e["to"] == "demo/test.rb:def:v:14")
-    );
-    assert!(
-        prop_edges
-            .iter()
-            .any(|e| e["to"] == "demo/test.rb:use:v:16")
-    );
+    assert!(prop_edges
+        .iter()
+        .all(|e| e["provenance"] == "symbolic_propagation"));
+    assert!(prop_edges
+        .iter()
+        .any(|e| e["to"] == "demo/test.rb:def:v:14"));
+    assert!(prop_edges
+        .iter()
+        .any(|e| e["to"] == "demo/test.rb:use:v:16"));
 }
 
 #[test]
@@ -2914,11 +2919,9 @@ fn ruby_alias_define_fixture_keeps_defined_sym_without_leaking_defined_only() {
     );
     let edges = prop["edges"].as_array().expect("edges array");
 
-    assert!(
-        edges
-            .iter()
-            .any(|e| e["to"] == "ruby:demo/test.rb:method:defined_sym:9")
-    );
+    assert!(edges
+        .iter()
+        .any(|e| e["to"] == "ruby:demo/test.rb:method:defined_sym:9"));
     assert!(
         !edges
             .iter()


### PR DESCRIPTION
## Summary
- add compact dropped-before-admit explanation labels to slice-selection pruned candidates
- carry those compact labels into witness selected-vs-pruned reasoning for suppressed-before-admit cases
- extend planner and CLI regressions for helper-noise, fallback-only, and same-path duplicate cases

## Testing
- cargo test --offline
- cargo clippy --offline
