### PR TITLE
Extend eval set for admission conflicts

### DIFF
--- a/docs/g8-6-evidence-driven-eval-set.json
+++ b/docs/g8-6-evidence-driven-eval-set.json
@@ -1,7 +1,7 @@
 {
-  "generated_by": "manual G8-6/G9 eval-set extension note",
+  "generated_by": "manual G8-6/G9/G10 eval-set extension note",
   "repo_root": "/home/shioriko/src/github.com/n01e0/dimpact",
-  "purpose": "fixed evidence-driven evaluation set covering G8 baseline plus G9 evidence-conflict regressions for negative evidence, semantic tie-breaks, dynamic fallback filtering, and losing-side witness reasons",
+  "purpose": "fixed evidence-driven evaluation set covering G8 baseline plus G9 evidence-conflict regressions and G10 evidence-budgeted admission / budget-exhaustion regressions",
   "defaults": {
     "engine": "ts",
     "cli_lanes": [
@@ -11,8 +11,8 @@
     "note": "treat current HEAD planner/unit tests as first-class lanes when the evidence surface is locked there more directly than in CLI output"
   },
   "totals": {
-    "cases": 7,
-    "rust": 3,
+    "cases": 9,
+    "rust": 5,
     "ruby": 4
   },
   "cases": [
@@ -24,11 +24,12 @@
         "docs/g8-3-rust-param-to-return-evidence.md",
         "tests/cli_pdg_propagation.rs::setup_cross_file_param_passthrough_competition_repo",
         "tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper",
+        "src/bin/dimpact.rs::bounded_slice_plan_prefers_rust_param_passthrough_over_later_neutral_helper",
         "src/bin/dimpact.rs::collect_rust_tier2_semantic_evidence_detects_param_to_return_flow"
       ],
-      "failure_kind": "rank_regression",
+      "failure_kind": "family_conflict_regression",
       "primary_view": "dot+json+unit_test",
-      "focus": "Rust Tier 2 competition where semantic param continuity must beat later neutral helper noise",
+      "focus": "Rust Tier 2 competition where semantic param continuity must beat a later sibling and keep that loser as same-family suppression metadata",
       "direction": "callees",
       "lanes": {
         "pdg": [
@@ -58,7 +59,16 @@
           "--",
           "--exact"
         ],
-        "unit": [
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_prefers_rust_param_passthrough_over_later_neutral_helper",
+          "--",
+          "--exact"
+        ],
+        "evidence_unit": [
           "cargo",
           "test",
           "--bin",
@@ -77,7 +87,7 @@
         "pruned_candidates": [
           {
             "path": "later.rs",
-            "prune_reason": "ranked_out"
+            "prune_reason": "weaker_same_family_sibling"
           }
         ],
         "selected_via_symbol_id": "rust:wrapper.rs:fn:wrap:4",
@@ -119,13 +129,14 @@
           "winning_support": {
             "local_dfg_support": true
           },
-          "summary": "selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support"
+          "summary": "selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support",
+          "prune_reason": "weaker_same_family_sibling"
         }
       },
       "regression_catch": [
         "later helper noise wins again because call position outweighs semantic param continuity",
-        "param_to_return_flow disappears from selected scoring",
-        "winning_support.local_dfg_support drops from witness explanation"
+        "same-family loser stops being recorded as weaker_same_family_sibling metadata",
+        "param_to_return_flow or winning_support.local_dfg_support drops from witness explanation"
       ]
     },
     {
@@ -353,6 +364,190 @@
       ]
     },
     {
+      "case_id": "rust-alias-helper-suppress-before-admit",
+      "lang": "rust",
+      "source_kind": "integration_fixture_plus_unit_guard",
+      "source": [
+        "src/bin/dimpact.rs::bounded_slice_plan_prefers_alias_continuation_over_later_adapter_helper_noise",
+        "tests/cli_pdg_propagation.rs::setup_cross_file_imported_result_alias_competition_repo",
+        "tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helper",
+        "src/impact.rs::selected_vs_pruned_reason_carries_compact_explanation_for_suppressed_before_admit"
+      ],
+      "failure_kind": "admission_conflict_regression",
+      "primary_view": "dot+json+unit_test",
+      "focus": "alias continuation stays selected while a later helper is pruned before admit and kept only as helper-noise suppression metadata",
+      "direction": "callees",
+      "lanes": {
+        "pdg": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-pdg",
+          "--format",
+          "dot"
+        ],
+        "propagation": [
+          "impact",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "json"
+        ]
+      },
+      "test_lanes": {
+        "integration": [
+          "cargo",
+          "test",
+          "--test",
+          "cli_pdg_propagation",
+          "pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helper",
+          "--",
+          "--exact"
+        ],
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_prefers_alias_continuation_over_later_adapter_helper_noise",
+          "--",
+          "--exact"
+        ],
+        "witness_unit": [
+          "cargo",
+          "test",
+          "--lib",
+          "selected_vs_pruned_reason_carries_compact_explanation_for_suppressed_before_admit",
+          "--",
+          "--exact"
+        ]
+      },
+      "expected_outcome": {
+        "selected_paths": [
+          "adapter.rs",
+          "main.rs",
+          "value.rs"
+        ],
+        "pruned_candidates": [
+          {
+            "path": "zzz_helper.rs",
+            "prune_reason": "suppressed_before_admit",
+            "compact_explanation": "suppressed_before_admit=helper_noise_suppressor"
+          }
+        ],
+        "selected_better_by": "primary_evidence_count",
+        "witness_symbol_id": "rust:value.rs:fn:make:1"
+      },
+      "expected_fields": {
+        "selected_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "alias_continuation",
+          "primary_evidence_kinds": [
+            "alias_chain",
+            "assigned_result"
+          ],
+          "secondary_evidence_kinds": [
+            "name_path_hint"
+          ]
+        },
+        "pruned_scoring": {
+          "source_kind": "graph_second_hop",
+          "lane": "alias_continuation",
+          "primary_evidence_kinds": [
+            "assigned_result"
+          ],
+          "secondary_evidence_kinds": [
+            "callsite_position_hint",
+            "name_path_hint"
+          ]
+        },
+        "witness_reason": {
+          "selected_better_by": "primary_evidence_count",
+          "winning_primary_evidence_kinds": [
+            "alias_chain"
+          ],
+          "compact_explanation": "suppressed_before_admit=helper_noise_suppressor",
+          "summary": "selected over zzz_helper.rs because it had more primary evidence (2 > 1); winning primary evidence: alias_chain"
+        }
+      },
+      "regression_catch": [
+        "alias helper noise survives into the compare pool",
+        "helper suppression metadata or compact explanation disappears",
+        "selected file drifts from value.rs to the helper side"
+      ]
+    },
+    {
+      "case_id": "rust-tier2-bridge-budget-exhaustion",
+      "lang": "rust",
+      "source_kind": "planner_unit_case",
+      "source": [
+        "src/bin/dimpact.rs::bounded_slice_plan_records_ranked_out_and_budget_pruned_tier2_candidates"
+      ],
+      "failure_kind": "budget_exhaustion_regression",
+      "primary_view": "unit_test",
+      "focus": "side-local suppress-before-admit losers and seed-wide bridge-budget losers remain distinguishable in tier-2 pruning metadata",
+      "direction": "callees",
+      "test_lanes": {
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_records_ranked_out_and_budget_pruned_tier2_candidates",
+          "--",
+          "--exact"
+        ]
+      },
+      "expected_outcome": {
+        "selected_paths": [
+          "a_leaf.rs",
+          "a_wrapper.rs",
+          "b_leaf.rs",
+          "b_wrapper.rs",
+          "c_wrapper.rs",
+          "main.rs"
+        ],
+        "pruned_candidates": [
+          {
+            "path": "z_alt.rs",
+            "prune_reason": "suppressed_before_admit",
+            "bridge_kind": "boundary_alias_continuation"
+          },
+          {
+            "path": "c_leaf.rs",
+            "prune_reason": "bridge_budget_exhausted",
+            "bridge_kind": "wrapper_return"
+          }
+        ]
+      },
+      "expected_fields": {
+        "cache_update_paths": [
+          "a_leaf.rs",
+          "a_wrapper.rs",
+          "b_leaf.rs",
+          "b_wrapper.rs",
+          "c_wrapper.rs",
+          "main.rs"
+        ],
+        "pruned_metadata": {
+          "z_alt.rs": {
+            "via_symbol_id": "rust:a_wrapper.rs:fn:wrap_a:3",
+            "bridge_kind": "boundary_alias_continuation"
+          },
+          "c_leaf.rs": {
+            "via_symbol_id": "rust:c_wrapper.rs:fn:wrap_c:3",
+            "bridge_kind": "wrapper_return"
+          }
+        }
+      },
+      "regression_catch": [
+        "side-local losers and budget losers collapse back into one generic ranked_out bucket",
+        "bridge_budget_exhausted disappears from pruned metadata",
+        "the final per-seed cap widens and c_leaf.rs leaks into the selected slice"
+      ]
+    },
+    {
       "case_id": "ruby-method-missing-companion-narrow-fallback",
       "lang": "ruby",
       "source_kind": "planner_unit_fixture",
@@ -427,9 +622,9 @@
         "tests/cli_pdg_propagation.rs::setup_ruby_dynamic_send_runtime_noise_repo",
         "tests/cli_pdg_propagation.rs::pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise"
       ],
-      "failure_kind": "fallback_noise_filter_regression",
+      "failure_kind": "admission_conflict_regression",
       "primary_view": "json+unit_test",
-      "focus": "generic dynamic runtime noise is filtered before candidate materialization unless it matches the literal target family",
+      "focus": "generic dynamic runtime noise is filtered before admission while same-path losers on the selected runtime stay visible as duplicate-suppression metadata",
       "direction": "callees",
       "lanes": {
         "propagation": [
@@ -469,7 +664,12 @@
           "lib/route_runtime.rb",
           "lib/service.rb"
         ],
-        "pruned_candidates": [],
+        "pruned_candidates": [
+          {
+            "path": "lib/route_runtime.rb",
+            "prune_reason": "weaker_same_path_duplicate"
+          }
+        ],
         "filtered_before_materialization": [
           "lib/aaa_runtime.rb"
         ]
@@ -498,12 +698,13 @@
           ],
           "selected_files_contains": [
             "lib/route_runtime.rb"
-          ]
+          ],
+          "pruned_candidates_compact_explanation": "suppressed_before_admit=weaker_same_path_duplicate"
         }
       },
       "regression_catch": [
         "generic dynamic runtime noise survives into fallback candidates",
-        "literal target family hints disappear from boundary evidence",
+        "same-path loser bookkeeping disappears from slice_selection.pruned_candidates",
         "the intended route runtime is filtered out together with the noise"
       ]
     },
@@ -581,12 +782,13 @@
       "lang": "ruby",
       "source_kind": "integration_fixture",
       "source": [
+        "src/bin/dimpact.rs::bounded_slice_plan_prefers_ruby_return_completion_over_later_require_relative_helper_noise",
         "tests/cli_pdg_propagation.rs::setup_ruby_require_relative_competing_leaf_repo",
         "tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise"
       ],
-      "failure_kind": "rank_regression",
-      "primary_view": "dot+json",
-      "focus": "CLI Ruby competition where selected/pruned witness output must keep the semantic leaf and exclude ranked-out helper noise",
+      "failure_kind": "admission_conflict_regression",
+      "primary_view": "dot+json+unit_test",
+      "focus": "CLI Ruby competition where the semantic leaf stays selected and the fallback-only helper is kept only as suppressed-before-admit metadata",
       "direction": "callees",
       "lanes": {
         "pdg": [
@@ -629,6 +831,15 @@
           "pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise",
           "--",
           "--exact"
+        ],
+        "planner_unit": [
+          "cargo",
+          "test",
+          "--bin",
+          "dimpact",
+          "bounded_slice_plan_prefers_ruby_return_completion_over_later_require_relative_helper_noise",
+          "--",
+          "--exact"
         ]
       },
       "expected_outcome": {
@@ -640,7 +851,8 @@
         "pruned_candidates": [
           {
             "path": "lib/zzz_helper.rb",
-            "prune_reason": "ranked_out"
+            "prune_reason": "suppressed_before_admit",
+            "compact_explanation": "suppressed_before_admit=fallback_only_suppressor"
           }
         ],
         "selected_better_by": "lane",
@@ -673,13 +885,14 @@
             "assigned_result",
             "return_flow"
           ],
-          "summary": "selected over lib/zzz_helper.rb because return_continuation outranked require_relative_continuation; winning primary evidence: assigned_result + return_flow"
+          "summary": "selected over lib/zzz_helper.rb because return_continuation outranked require_relative_continuation; winning primary evidence: assigned_result + return_flow",
+          "compact_explanation": "suppressed_before_admit=fallback_only_suppressor"
         }
       },
       "regression_catch": [
         "later helper noise outranks the semantic leaf",
-        "ranked-out helper leaks into selected_files_on_path explanation context",
-        "Ruby CLI witness summary loses the winning evidence surface"
+        "suppressed_before_admit=fallback_only_suppressor disappears from pruned or witness metadata",
+        "Ruby helper leaks into selected_files_on_path explanation context"
       ]
     }
   ]

--- a/docs/g8-6-evidence-driven-eval-set.md
+++ b/docs/g8-6-evidence-driven-eval-set.md
@@ -2,19 +2,20 @@
 
 このメモは、G8 で入った evidence-driven selection / true narrow fallback / witness explanation を
 毎回戻って比較する **固定評価セット** を定義し、
-G9 で入った evidence conflict 系の改善をそこへ追加で固定するためのもの。
+G9 の evidence conflict 系改善に加えて、
+G10 で入った **admission conflict / suppress-before-admit / budget exhaustion** をそこへ追加で固定するためのもの。
 
 G5/G7 までは主に bounded slice の広げ方と selected/pruned surface を固定していた。
-G8 では scope widening ではなく、
+G8/G9 では scope widening ではなく、
 **同じ bounded slice の中で何の evidence が勝敗を決め、どう witness へ出るか** を固定した。
-G9 ではその続きとして、
-**negative / suppressing evidence、same-kind tie-break、dynamic fallback noise filter、losing-side reason**
-を固定評価セットへ足す。
+G10 ではその続きとして、
+**admit する前に弱い候補を落とすこと、same-family / same-path loser を明示的に残すこと、raw cap を budget exhaustion として区別して残すこと**
+を fixed baseline へ足す。
 
-したがって現 HEAD の fixed set は、G8 の 4 ケースを維持しつつ、
-G9 で増えた evidence conflict ケースを追加した **7 ケース** で構成する。
+したがって現 HEAD の fixed set は、G8/G9 の 7 ケースを維持しつつ、
+G10 の admission conflict / budget exhaustion ケースを追加した **9 ケース** で構成する。
 
-- Rust: 3 ケース
+- Rust: 5 ケース
 - Ruby: 4 ケース
 
 machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
@@ -23,28 +24,32 @@ machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 
 ## 1. この評価セットで見るもの
 
-現行の fixed set で見たいのは主に次の 7 種類。
+現行の fixed set で見たいのは主に次の 9 種類。
 
 1. **semantic evidence が positional noise に勝つこと**
-   - `param_to_return_flow` が取れた Rust leaf が、後ろにある neutral helper を rank で押し切れるか
+   - `param_to_return_flow` が取れた Rust leaf が later helper を押し切れるか
 2. **negative / suppressing evidence が noisy helper を落とすこと**
-   - return-ish helper noise が later callsite や lexical hint を持っていても selected されないか
+   - return-ish helper noise が lexical hint や later callsite を持っていても selected されないか
 3. **same-kind 候補で semantic support の強さが tie-break になること**
-   - evidence kind 名が同じ Rust 候補同士でも、より強い semantic aggregation を持つ方が勝てるか
-4. **true narrow fallback が bounded に materialize されること**
+   - 同じ evidence kind を持つ Rust 候補同士で、強い semantic aggregation を持つ方が勝てるか
+4. **alias 系の明らかに弱い helper が compare 前に suppress されること**
+   - alias continuation を壊さず helper noise だけが `suppressed_before_admit` として残るか
+5. **same-family sibling が ranked-out ではなく family conflict として残ること**
+   - `param_to_return_flow` を持つ leaf が later sibling を `weaker_same_family_sibling` として落とせるか
+6. **per-seed raw cap が budget exhaustion として明示されること**
+   - side-local loser と seed-wide loser が同じ `ranked_out` に潰れず区別されるか
+7. **true narrow fallback が bounded に materialize されること**
    - Ruby `method_missing` companion が graph-first へ滲まず narrow fallback lane として選ばれるか
-5. **dynamic-send 系の generic runtime noise が fallback candidate へ残らないこと**
-   - literal target family と関係のない generic runtime が filtering されるか
-6. **winner/pruned 差分と losing-side reason が witness へそのまま出ること**
-   - `winning_primary_evidence_kinds` / `winning_support` / `losing_side_reason` / `summary` が安定しているか
-7. **CLI の selected/pruned witness surface が Ruby 競合ケースでも崩れないこと**
-   - selected file と ranked-out helper の分離、説明 slice、summary 文面が保たれるか
+8. **Ruby fallback-only / dynamic runtime noise が admit 前に落ちること**
+   - weak require_relative helper や unrelated runtime family が bounded candidate として残らないか
+9. **winner/pruned 差分と compact explanation が witness / slice summary に残ること**
+   - `winning_primary_evidence_kinds` / `winning_support` / `compact_explanation` / `summary` が安定しているか
 
 ---
 
 ## 2. 固定ルール
 
-## 2.1 lane の扱い
+### 2.1 lane の扱い
 
 この set では、**CLI lane と test lane を両方 first-class に扱う**。
 
@@ -59,18 +64,18 @@ machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 理由:
 
 - Rust / Ruby の competition と filtering は CLI integration で固定するのが最も実態に近い
-- true narrow fallback の raw boundary/candidate evidence は planner unit が最も直接
+- true narrow fallback / budget exhaustion / same-path duplicate の raw metadata は planner unit が最も直接
 - witness explanation の最小面は `src/impact.rs` unit が最も直接
 
-## 2.2 engine / format
+### 2.2 engine / format
 
 - CLI lane の engine は `ts` 安定面を前提にする
 - selected/pruned / scoring / witness explanation が本題のケースは `json`
 - selected file の入り方自体を見たいケースだけ `dot` を併用する
 
-## 2.3 更新ルール
+### 2.3 更新ルール
 
-この 7 ケースは、現行 evidence conflict surface の fixed baseline として扱う。
+この 9 ケースは、現行 evidence-budgeted admission surface の fixed baseline として扱う。
 置換するなら、「より直接で、現 HEAD に既に存在する coverage へ置き換える理由」を別メモに残す。
 
 ---
@@ -79,113 +84,78 @@ machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 
 | case_id | lang | kind | primary view | ねらい |
 | --- | --- | --- | --- | --- |
-| rust-param-to-return-flow-competition | rust | rank regression | dot + json + unit | `param_to_return_flow` が later helper noise に勝つ Rust Tier 2 competition |
-| rust-returnish-helper-negative-evidence | rust | suppressing regression | dot + json + unit | `noisy_return_hint` が later return-ish helper を ranked-out に留める |
+| rust-param-to-return-flow-competition | rust | family conflict regression | dot + json + unit | `param_to_return_flow` leaf が later sibling を `weaker_same_family_sibling` で落とす |
+| rust-returnish-helper-negative-evidence | rust | suppressing regression | dot + json + unit | `noisy_return_hint` が return-ish helper を ranked-out に留める |
 | rust-semantic-support-tiebreak | rust | tie-break regression | dot + json + unit | 同種 evidence の Rust 候補で `semantic_support_rank` が later callsite hint に勝つ |
-| ruby-method-missing-companion-narrow-fallback | ruby | narrow fallback FN | planner unit | `method_missing` companion を true narrow fallback lane で選ぶ Tier 3 case |
-| ruby-dynamic-runtime-target-family-filter | ruby | fallback noise filter | json + planner unit | generic dynamic runtime noise を literal target family hint で事前 filtering する |
+| rust-alias-helper-suppress-before-admit | rust | admission conflict regression | dot + json + unit | alias continuation を壊さず helper noise を `suppressed_before_admit` で残す |
+| rust-tier2-bridge-budget-exhaustion | rust | budget exhaustion regression | planner unit | side-local loser と seed-wide loser を別 prune reason で残す |
+| ruby-method-missing-companion-narrow-fallback | ruby | narrow fallback FN | planner unit | `method_missing` companion を true narrow fallback lane で選ぶ |
+| ruby-dynamic-runtime-target-family-filter | ruby | admission conflict regression | json + planner unit | generic runtime noise を filtering しつつ same-path duplicate を残す |
 | ruby-winning-evidence-source-kind-explanation | ruby | explanation regression | lib unit | selected/pruned の勝ち筋 evidence/support と losing-side reason が witness summary に出る |
-| ruby-require-relative-leaf-competition | ruby | rank regression | dot + json | selected/pruned witness surface を CLI で固定する require_relative competition |
+| ruby-require-relative-leaf-competition | ruby | admission conflict regression | dot + json + unit | fallback-only helper を `suppressed_before_admit` で残しつつ semantic leaf を選ぶ |
 
 ---
 
 ## 4. 各ケースの固定意図
 
-## 4.1 `rust-param-to-return-flow-competition`
+### 4.1 `rust-param-to-return-flow-competition`
 
-### Source
+**Source**
 
 - `docs/g8-3-rust-param-to-return-evidence.md`
 - `tests/cli_pdg_propagation.rs::setup_cross_file_param_passthrough_competition_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper`
+- `src/bin/dimpact.rs::bounded_slice_plan_prefers_rust_param_passthrough_over_later_neutral_helper`
 - `src/bin/dimpact.rs::collect_rust_tier2_semantic_evidence_detects_param_to_return_flow`
 
-### Fixed lane
-
-- CLI:
-  - `impact --direction callees --with-pdg --format dot`
-  - `impact --direction callees --with-propagation --format json`
-- test:
-  - `cargo test --test cli_pdg_propagation pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper -- --exact`
-  - `cargo test --bin dimpact collect_rust_tier2_semantic_evidence_detects_param_to_return_flow -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected files は `main.rs`, `step.rs`, `wrapper.rs`
-- `later.rs` は `pruned_candidates[*].prune_reason = ranked_out`
+- `later.rs` は `pruned_candidates[*].prune_reason = weaker_same_family_sibling`
 - selected は Tier 2 `bridge_completion_file` / `via_symbol_id = rust:wrapper.rs:fn:wrap:4`
 - witness では `rust:step.rs:fn:step:1` 側に selected-vs-pruned explanation が付く
 
-### Expected fields
+**Expected fields**
 
 - selected scoring:
-  - `source_kind = graph_second_hop`
   - `lane = return_continuation`
   - `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
-  - `secondary_evidence_kinds = [name_path_hint]`
   - `support.local_dfg_support = true`
 - pruned scoring (`later.rs`):
+  - `lane = return_continuation`
   - `primary_evidence_kinds = [assigned_result, return_flow]`
   - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
 - witness reason:
+  - `prune_reason = weaker_same_family_sibling`
   - `selected_better_by = primary_evidence_count`
   - `winning_primary_evidence_kinds = [param_to_return_flow]`
   - `winning_support.local_dfg_support = true`
-  - summary:
-    - `selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support`
 
-### Regression to catch
+**Regression to catch**
 
-- last-call / lexical noise が再び勝って `later.rs` が選ばれる
-- `param_to_return_flow` が selected scoring から落ちる
-- `winning_support.local_dfg_support` が witness explanation から消える
+- later helper noise が再び selected へ残る
+- same-family loser が `weaker_same_family_sibling` で残らなくなる
+- `param_to_return_flow` / `local_dfg_support` が witness explanation から落ちる
 
 ---
 
-## 4.2 `rust-returnish-helper-negative-evidence`
+### 4.2 `rust-returnish-helper-negative-evidence`
 
-### Source
+**Source**
 
 - `src/bin/dimpact.rs::bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion`
 - `tests/cli_pdg_propagation.rs::setup_cross_file_returnish_helper_noise_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite`
 - `src/impact.rs::selected_vs_pruned_reason_derives_losing_side_reason_from_negative_evidence`
 
-### Fixed lane
-
-- CLI:
-  - `impact --direction callees --with-pdg --format dot`
-  - `impact --direction callees --with-propagation --format json`
-- test:
-  - `cargo test --bin dimpact bounded_slice_plan_penalizes_returnish_helper_noise_against_real_return_completion -- --exact`
-  - `cargo test --test cli_pdg_propagation pdg_slice_selection_penalizes_returnish_helper_noise_after_later_callsite -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected files は `leaf.rs`, `main.rs`, `wrapper.rs`
 - `zzz_final_helper.rs` は `ranked_out`
-- selected/pruned は両方 `wrapper_return` competition だが、helper 側だけ `negative_evidence_kinds = [noisy_return_hint]` を持つ
-- witness では compact な losing-side reason が出る
+- helper 側だけ `negative_evidence_kinds = [noisy_return_hint]` を持つ
+- witness では `losing_side_reason = negative_evidence=noisy_return_hint` が出る
 
-### Expected fields
-
-- selected scoring (`leaf.rs`):
-  - `source_kind = graph_second_hop`
-  - `lane = return_continuation`
-  - `primary_evidence_kinds = [assigned_result, return_flow]`
-  - `secondary_evidence_kinds = [name_path_hint]`
-- pruned scoring (`zzz_final_helper.rs`):
-  - `primary_evidence_kinds = [assigned_result, return_flow]`
-  - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
-  - `negative_evidence_kinds = [noisy_return_hint]`
-  - `score_tuple.negative_evidence_count = 1`
-- witness reason:
-  - `selected_better_by = negative_evidence_count`
-  - `losing_side_reason = negative_evidence=noisy_return_hint`
-  - summary:
-    - `selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint`
-
-### Regression to catch
+**Regression to catch**
 
 - later return-ish helper が call position や lexical hint で再び勝つ
 - `negative_evidence_kinds` が pruned metadata から落ちる
@@ -193,245 +163,222 @@ machine-readable set: `docs/g8-6-evidence-driven-eval-set.json`
 
 ---
 
-## 4.3 `rust-semantic-support-tiebreak`
+### 4.3 `rust-semantic-support-tiebreak`
 
-### Source
+**Source**
 
 - `src/bin/dimpact.rs::bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint`
 - `tests/cli_pdg_propagation.rs::setup_cross_file_semantic_support_competition_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint`
 
-### Fixed lane
-
-- CLI:
-  - `impact --direction callees --with-pdg --format dot`
-  - `impact --direction callees --with-propagation --format json`
-- test:
-  - `cargo test --bin dimpact bounded_slice_plan_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact`
-  - `cargo test --test cli_pdg_propagation pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsite_hint -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected files は `main.rs`, `steady.rs`, `wrapper.rs`
 - `plain.rs` は `ranked_out`
-- selected/pruned は両方 `return_continuation` かつ `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
-- tie-break は `secondary_evidence_count` や `call_position_rank` より前に `semantic_support_rank` で決まる
+- selected/pruned は両方 `return_continuation` かつ同じ primary evidence kind を持つ
+- tie-break は `semantic_support_rank` で決まる
 
-### Expected fields
+**Regression to catch**
 
-- selected scoring (`steady.rs`):
-  - `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
-  - `secondary_evidence_kinds = [name_path_hint]`
-  - `score_tuple.semantic_support_rank = 3`
-  - `support.local_dfg_support = true`
-- pruned scoring (`plain.rs`):
-  - `primary_evidence_kinds = [assigned_result, param_to_return_flow, return_flow]`
-  - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
-  - `score_tuple.semantic_support_rank = 2`
-  - `support.local_dfg_support = true`
-- witness reason:
-  - `selected_better_by = semantic_support_rank`
-  - summary:
-    - `selected over plain.rs because it had stronger semantic support (3 > 2)`
-
-### Regression to catch
-
-- same-kind 候補が再び later callsite hint だけで決まる
+- same-kind 候補が later callsite hint だけで決まる
 - `semantic_support_rank` が score tuple から落ちる
 - stronger semantic leaf が `plain.rs` に押し負ける
 
 ---
 
-## 4.4 `ruby-method-missing-companion-narrow-fallback`
+### 4.4 `rust-alias-helper-suppress-before-admit`
 
-### Source
+**Source**
+
+- `src/bin/dimpact.rs::bounded_slice_plan_prefers_alias_continuation_over_later_adapter_helper_noise`
+- `tests/cli_pdg_propagation.rs::setup_cross_file_imported_result_alias_competition_repo`
+- `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_alias_continuation_value_over_later_adapter_helper`
+- `src/impact.rs::selected_vs_pruned_reason_carries_compact_explanation_for_suppressed_before_admit`
+
+**Locked outcome**
+
+- selected files は `adapter.rs`, `main.rs`, `value.rs`
+- `zzz_helper.rs` は `suppressed_before_admit`
+- helper 側には `compact_explanation = suppressed_before_admit=helper_noise_suppressor` が付く
+- witness でも同じ compact explanation が selected/pruned 理由へ引き継がれる
+
+**Expected fields**
+
+- selected scoring:
+  - `lane = alias_continuation`
+  - `primary_evidence_kinds = [alias_chain, assigned_result]`
+- pruned scoring:
+  - `lane = alias_continuation`
+  - `primary_evidence_kinds = [assigned_result]`
+  - `secondary_evidence_kinds = [callsite_position_hint, name_path_hint]`
+- witness reason:
+  - `selected_better_by = primary_evidence_count`
+  - `winning_primary_evidence_kinds = [alias_chain]`
+  - `compact_explanation = suppressed_before_admit=helper_noise_suppressor`
+
+**Regression to catch**
+
+- alias helper noise が compare pool へ残って rank contest を汚す
+- `suppressed_before_admit=helper_noise_suppressor` が pruned/witness metadata から落ちる
+- selected file が alias continuation ではなく helper 側へぶれる
+
+---
+
+### 4.5 `rust-tier2-bridge-budget-exhaustion`
+
+**Source**
+
+- `src/bin/dimpact.rs::bounded_slice_plan_records_ranked_out_and_budget_pruned_tier2_candidates`
+
+**Locked outcome**
+
+- selected files は `a_leaf.rs`, `a_wrapper.rs`, `b_leaf.rs`, `b_wrapper.rs`, `c_wrapper.rs`, `main.rs`
+- `z_alt.rs` は side-local loser として `suppressed_before_admit`
+- `c_leaf.rs` は seed-wide loser として `bridge_budget_exhausted`
+- same test の中で admission conflict と final seed budget が別 surface として観測できる
+
+**Expected fields**
+
+- `z_alt.rs`
+  - `bridge_kind = boundary_alias_continuation`
+  - `via_symbol_id = rust:a_wrapper.rs:fn:wrap_a:3`
+- `c_leaf.rs`
+  - `bridge_kind = wrapper_return`
+  - `via_symbol_id = rust:c_wrapper.rs:fn:wrap_c:3`
+  - `prune_reason = bridge_budget_exhausted`
+
+**Regression to catch**
+
+- side-local loser と budget loser が同じ `ranked_out` に潰れる
+- `bridge_budget_exhausted` candidate が pruned metadata から落ちる
+- final cap を widen してしまい `c_leaf.rs` が selected へ混ざる
+
+---
+
+### 4.6 `ruby-method-missing-companion-narrow-fallback`
+
+**Source**
 
 - `docs/g8-1-missing-evidence-inventory-and-design-memo.md`
 - `docs/g8-2-bridge-scoring-evidence-schema.json`
 - `src/bin/dimpact.rs::bounded_slice_plan_selects_ruby_method_missing_companion_as_narrow_fallback`
 - `tests/fixtures/ruby/analyzer_hard_cases_dynamic_dsl_method_missing_chain_v4.rb`
 
-### Fixed lane
-
-- test:
-  - `cargo test --bin dimpact bounded_slice_plan_selects_ruby_method_missing_companion_as_narrow_fallback -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected narrow fallback file は `lib/runtime.rb`
 - reason は Tier 3 `module_companion_file`
 - `via_path` は temp repo 上の `lib/router.rb`
-- `cache_update_paths` は temp repo 上の `app/main.rb`, `lib/router.rb`, `lib/runtime.rb`
 - `pruned_candidates` は空
 
-### Expected fields
-
-- boundary evidence:
-  - `explicit_require_relative_loads` は temp repo 上の `lib/runtime.rb` を含む
-  - `literal_dynamic_targets = { "route_created": 9 }`
-- candidate evidence:
-  - `matched_call_line = 9`
-  - `edge_certainty = dynamic_fallback`
-- selected scoring:
-  - `source_kind = narrow_fallback`
-  - `lane = module_companion_fallback`
-  - `primary_evidence_kinds = [companion_file_match, dynamic_dispatch_literal_target, explicit_require_relative_load]`
-  - `secondary_evidence_kinds = []`
-  - `support.edge_certainty = dynamic_fallback`
-
-### Regression to catch
+**Regression to catch**
 
 - true narrow fallback が materialize されず runtime companion を拾えない
 - `companion_file_match` / `dynamic_dispatch_literal_target` / `explicit_require_relative_load` の 3 点が scoring に揃わない
-- narrow fallback candidate が graph-first 由来の selected reason に化ける
+- narrow fallback candidate が graph-first selected reason に化ける
 
 ---
 
-## 4.5 `ruby-dynamic-runtime-target-family-filter`
+### 4.7 `ruby-dynamic-runtime-target-family-filter`
 
-### Source
+**Source**
 
 - `src/bin/dimpact.rs::ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint`
 - `tests/cli_pdg_propagation.rs::setup_ruby_dynamic_send_runtime_noise_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise`
 
-### Fixed lane
-
-- CLI:
-  - `impact --direction callees --lang ruby --with-propagation --format json`
-- test:
-  - `cargo test --bin dimpact ruby_narrow_fallback_filters_generic_dynamic_runtime_without_target_family_hint -- --exact`
-  - `cargo test --test cli_pdg_propagation pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected files は `app/runner.rb`, `lib/route_runtime.rb`, `lib/service.rb`
-- `pruned_candidates = []`
 - `lib/aaa_runtime.rb` は candidate materialization 前に filtering される
-- family-specific runtime だけが `via_path = lib/service.rb` を通って残る
+- same selected path へ収束した loser は `weaker_same_path_duplicate` として残る
+- `compact_explanation = suppressed_before_admit=weaker_same_path_duplicate` が付く
 
-### Expected fields
+**Expected fields**
 
 - boundary evidence:
-  - `explicit_require_relative_loads` は `lib/aaa_runtime.rb`, `lib/route_runtime.rb` を両方含む
+  - `explicit_require_relative_loads` は `lib/aaa_runtime.rb`, `lib/route_runtime.rb` を含む
   - `literal_dynamic_target_hints = [route_, route_created]`
-- candidate filtering:
-  - `collect_ruby_narrow_fallback_candidate_evidence(lib/aaa_runtime.rb, ...) = None`
-  - `collect_ruby_narrow_fallback_candidate_evidence(lib/route_runtime.rb, ...)` は `matched_call_line = 10` / `edge_certainty = dynamic_fallback`
 - CLI outcome:
-  - `lib/aaa_runtime.rb` は `impacted_files` に入らない
-  - `lib/route_runtime.rb` は selected file に残る
+  - `impacted_files` は `lib/aaa_runtime.rb` を含まない
+  - selected file は `lib/route_runtime.rb`
+  - pruned candidate は `path = lib/route_runtime.rb`, `prune_reason = weaker_same_path_duplicate`
 
-### Regression to catch
+**Regression to catch**
 
-- generic dynamic runtime noise が再び fallback candidate へ残る
-- literal target family hint が boundary evidence から落ちる
+- generic runtime noise が fallback candidate へ残る
+- same-path loser bookkeeping が消えて duplicate admission conflict が追えなくなる
 - intended runtime (`route_runtime.rb`) まで filtering される
 
 ---
 
-## 4.6 `ruby-winning-evidence-source-kind-explanation`
+### 4.8 `ruby-winning-evidence-source-kind-explanation`
 
-### Source
+**Source**
 
 - `docs/g8-1-missing-evidence-inventory-and-design-memo.md`
 - `docs/g8-2-bridge-scoring-evidence-schema.json`
 - `src/impact.rs::selected_vs_pruned_reason_derives_winning_metadata_for_source_kind_explanations`
 
-### Fixed lane
-
-- test:
-  - `cargo test --lib selected_vs_pruned_reason_derives_winning_metadata_for_source_kind_explanations -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected は `lib/leaf.rb`
 - pruned は `lib/helper.rb`
 - `selected_better_by = source_kind`
+- witness summary には winning evidence / winning support / losing-side reason が揃う
 
-### Expected fields
-
-- selected scoring support:
-  - `symbolic_propagation_support = true`
-  - `edge_certainty = confirmed`
-- pruned scoring support:
-  - `edge_certainty = dynamic_fallback`
-- witness reason:
-  - `winning_primary_evidence_kinds = [explicit_require_relative_load]`
-  - `winning_support.symbolic_propagation_support = true`
-  - `winning_support.edge_certainty = confirmed`
-  - `losing_side_reason = fallback_only=narrow_fallback + edge_certainty=dynamic_fallback`
-  - summary:
-    - `selected over lib/helper.rb because graph_second_hop outranked narrow_fallback; winning primary evidence: explicit_require_relative_load; winning support: symbolic_propagation_support + edge_certainty=confirmed; losing side: fallback_only=narrow_fallback + edge_certainty=dynamic_fallback`
-
-### Regression to catch
+**Regression to catch**
 
 - `winning_primary_evidence_kinds` が selected/pruned 差分から導けなくなる
 - `winning_support` が support 差分を落とす
 - `losing_side_reason` が fallback-only / dynamic_fallback を落とす
-- source-kind 勝敗の summary が evidence/support/losing-side なしの薄い文面へ戻る
 
 ---
 
-## 4.7 `ruby-require-relative-leaf-competition`
+### 4.9 `ruby-require-relative-leaf-competition`
 
-### Source
+**Source**
 
+- `src/bin/dimpact.rs::bounded_slice_plan_prefers_ruby_return_completion_over_later_require_relative_helper_noise`
 - `tests/cli_pdg_propagation.rs::setup_ruby_require_relative_competing_leaf_repo`
 - `tests/cli_pdg_propagation.rs::pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise`
 
-### Fixed lane
-
-- CLI:
-  - `impact --direction callees --lang ruby --with-pdg --format dot`
-  - `impact --direction callees --lang ruby --with-propagation --format json`
-  - `impact --direction callees --lang ruby --with-propagation --format dot`
-- test:
-  - `cargo test --test cli_pdg_propagation pdg_slice_selection_prefers_ruby_require_relative_leaf_over_later_helper_noise -- --exact`
-
-### Locked outcome
+**Locked outcome**
 
 - selected files は `app/runner.rb`, `lib/leaf.rb`, `lib/service.rb`
-- `lib/zzz_helper.rb` は `ranked_out`
+- `lib/zzz_helper.rb` は `suppressed_before_admit`
+- helper 側には `compact_explanation = suppressed_before_admit=fallback_only_suppressor` が付く
 - helper witness の `selected_files_on_path` には `lib/zzz_helper.rb` が入らない
-- propagation dot では `app/runner.rb:use:prepared:5 -> app/runner.rb:def:reply:5` の bridge が出る
 
-### Expected fields
+**Expected fields**
 
-- selected scoring (`lib/leaf.rb`):
-  - `source_kind = graph_second_hop`
+- selected scoring:
   - `lane = return_continuation`
   - `primary_evidence_kinds = [assigned_result, return_flow]`
-  - `secondary_evidence_kinds = [name_path_hint]`
-- pruned scoring (`lib/zzz_helper.rb`):
-  - `source_kind = graph_second_hop`
+- pruned scoring:
   - `lane = require_relative_continuation`
   - `primary_evidence_kinds = [require_relative_edge]`
   - `secondary_evidence_kinds = [callsite_position_hint]`
 - witness reason:
   - `selected_better_by = lane`
   - `winning_primary_evidence_kinds = [assigned_result, return_flow]`
-  - summary:
-    - `selected over lib/zzz_helper.rb because return_continuation outranked require_relative_continuation; winning primary evidence: assigned_result + return_flow`
+  - `compact_explanation = suppressed_before_admit=fallback_only_suppressor`
 
-### Regression to catch
+**Regression to catch**
 
-- helper noise が lane/position で勝って `lib/leaf.rb` を押しのける
-- ranked-out helper が explanation slice に混ざる
-- Ruby CLI witness surface から winning evidence の summary が落ちる
+- fallback-only helper が compare pool を抜けて semantic leaf を押しのける
+- `suppressed_before_admit=fallback_only_suppressor` が pruned/witness metadata から落ちる
+- Ruby helper が explanation slice に混ざる
 
 ---
 
-## 5. この set が G9 で追加で守るもの
+## 5. 一言まとめ
 
-G8 時点の fixed set は「改善が効いたこと」を押さえるには十分だったが、
-evidence conflict の正規化面はまだ薄かった。
-現行の 7 ケースでは、少なくとも次が固定される。
+G8/G9 までは、主に **何の evidence が selected/pruned の勝敗を決めるか** を固定していた。
+G10 でこの fixed set に足したいのは、
+**何をそもそも admit しないか、same-family / same-path loser をどう残すか、raw cap を budget exhaustion としてどう区別するか**
+である。
 
-- `negative_evidence_kinds` が noisy helper suppression と witness summary の両方へ出ること
-- `semantic_support_rank` が same-kind Rust competition の compare order に入ること
-- Ruby true narrow fallback が literal dynamic target family によって bounded に絞られること
-- witness が winning-side だけでなく losing-side の簡易理由も持てること
-
-これにより、G9-3〜G9-6 で入った evidence conflict surface が
-固定評価セットの上でも regression 監視できるようになる。
+したがって現行の eval set は、
+**ranking regression の固定セット** であると同時に、
+**evidence-budgeted admission / suppression / budget の固定セット** でもある。


### PR DESCRIPTION
## Summary
- update the fixed evidence-driven eval set note for current G10 planner behavior
- add explicit admission-conflict coverage for suppress-before-admit and same-family/same-path loser bookkeeping
- add a dedicated bridge-budget-exhaustion eval case alongside the updated machine-readable JSON

## Testing
- python3 -m json.tool docs/g8-6-evidence-driven-eval-set.json >/dev/null
- cargo test --offline
- cargo clippy --offline
