### PR TITLE
Add non-widening regression coverage

### DIFF
--- a/src/impact.rs
+++ b/src/impact.rs
@@ -3398,6 +3398,123 @@ fn foo() { bar(); }
     }
 
     #[test]
+    fn selected_vs_pruned_reason_ignores_same_path_duplicates_and_budget_exhaustion() {
+        let seed_symbol_id = "ruby:app/runner.rb:method:entry:3".to_string();
+        let via_symbol_id = "ruby:lib/service.rb:method:bounce:4".to_string();
+        let reasons = build_selected_vs_pruned_reasons(
+            "lib/route_runtime.rb",
+            &[ImpactSliceReasonMetadata {
+                seed_symbol_id: seed_symbol_id.clone(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some(via_symbol_id.clone()),
+                via_path: Some("lib/service.rb".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::AliasContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AliasChain,
+                        ImpactSliceEvidenceKind::AssignedResult,
+                    ],
+                    secondary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::CallsitePositionHint,
+                        ImpactSliceEvidenceKind::NamePathHint,
+                    ],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 1,
+                        primary_evidence_count: 2,
+                        secondary_evidence_count: 2,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 7,
+                        lexical_tiebreak: "lib/route_runtime.rb".to_string(),
+                    },
+                    support: None,
+                }),
+            }],
+            &[
+                ImpactSlicePrunedCandidate {
+                    seed_symbol_id: seed_symbol_id.clone(),
+                    path: "lib/route_runtime.rb".to_string(),
+                    tier: 2,
+                    kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                    via_symbol_id: Some(via_symbol_id.clone()),
+                    via_path: Some("lib/service.rb".to_string()),
+                    bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                    prune_reason: ImpactSlicePruneReason::WeakerSamePathDuplicate,
+                    scoring: Some(ImpactSliceCandidateScoringSummary {
+                        source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                        lane: ImpactSliceCandidateLane::AliasContinuation,
+                        primary_evidence_kinds: vec![
+                            ImpactSliceEvidenceKind::AliasChain,
+                            ImpactSliceEvidenceKind::AssignedResult,
+                        ],
+                        secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                        negative_evidence_kinds: vec![],
+                        score_tuple: ImpactSliceScoreTuple {
+                            source_rank: 0,
+                            lane_rank: 1,
+                            primary_evidence_count: 2,
+                            secondary_evidence_count: 1,
+                            negative_evidence_count: 0,
+                            semantic_support_rank: 0,
+                            call_position_rank: 4,
+                            lexical_tiebreak: "lib/route_runtime.rb".to_string(),
+                        },
+                        support: None,
+                    }),
+                    compact_explanation: Some(
+                        "suppressed_before_admit=weaker_same_path_duplicate".to_string(),
+                    ),
+                },
+                ImpactSlicePrunedCandidate {
+                    seed_symbol_id,
+                    path: "lib/fallback_runtime.rb".to_string(),
+                    tier: 2,
+                    kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                    via_symbol_id: Some(via_symbol_id),
+                    via_path: Some("lib/service.rb".to_string()),
+                    bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                    prune_reason: ImpactSlicePruneReason::BridgeBudgetExhausted,
+                    scoring: Some(ImpactSliceCandidateScoringSummary {
+                        source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                        lane: ImpactSliceCandidateLane::AliasContinuation,
+                        primary_evidence_kinds: vec![
+                            ImpactSliceEvidenceKind::AliasChain,
+                            ImpactSliceEvidenceKind::AssignedResult,
+                        ],
+                        secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                        negative_evidence_kinds: vec![],
+                        score_tuple: ImpactSliceScoreTuple {
+                            source_rank: 0,
+                            lane_rank: 1,
+                            primary_evidence_count: 2,
+                            secondary_evidence_count: 1,
+                            negative_evidence_count: 0,
+                            semantic_support_rank: 0,
+                            call_position_rank: 8,
+                            lexical_tiebreak: "lib/fallback_runtime.rb".to_string(),
+                        },
+                        support: Some(ImpactSliceCandidateSupportMetadata {
+                            edge_certainty: Some(ImpactSliceSupportEdgeCertainty::DynamicFallback),
+                            ..ImpactSliceCandidateSupportMetadata::default()
+                        }),
+                    }),
+                    compact_explanation: Some("bridge_budget_exhausted".to_string()),
+                },
+            ],
+        );
+
+        assert!(
+            reasons.is_empty(),
+            "expected same-path duplicates and bridge-budget drops to stay out of witness selected-vs-pruned explanation scope"
+        );
+    }
+
+    #[test]
     fn selected_vs_pruned_reason_omits_optional_winning_fields_when_absent() {
         let reason = ImpactWitnessSliceSelectedVsPrunedReason {
             via_symbol_id: Some("rust:wrapper.rs:fn:wrap:2".to_string()),

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1894,6 +1894,12 @@ fn pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper(
         .filter_map(|file| file["path"].as_str())
         .collect();
     assert_eq!(paths, vec!["main.rs", "step.rs", "wrapper.rs"]);
+    assert!(
+        !serde_json::to_string(&slice_selection["files"])
+            .expect("serialize slice_selection.files")
+            .contains("later.rs"),
+        "unexpected later.rs leaked into slice_selection.files explanation scope: {prop:#}"
+    );
 
     let step = slice_selection_file(slice_selection, "step.rs");
     assert!(
@@ -1986,6 +1992,14 @@ fn pdg_slice_selection_prefers_param_passthrough_leaf_over_later_neutral_helper(
             },
             "summary": "selected over later.rs because it had more primary evidence (3 > 2); winning primary evidence: param_to_return_flow; winning support: local_dfg_support",
         }])
+    );
+
+    let later_witness = &prop["impacted_witnesses"]["rust:later.rs:fn:later:1"];
+    let later_paths = witness_slice_paths(later_witness);
+    assert_eq!(
+        later_paths,
+        vec!["main.rs", "wrapper.rs"],
+        "expected weaker same-family sibling later.rs to stay outside the selected explanation slice even if it remains reachable: {prop:#}"
     );
 }
 
@@ -2357,6 +2371,12 @@ fn pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise() {
         "expected family-specific runtime to remain selected through lib/service.rb after filtering generic runtime noise: {prop:#}"
     );
     assert!(
+        !serde_json::to_string(&slice_selection["files"])
+            .expect("serialize slice_selection.files")
+            .contains("weaker_same_path_duplicate"),
+        "unexpected same-path duplicate prune metadata widened slice_selection.files explanation scope: {prop:#}"
+    );
+    assert!(
         !prop["impacted_files"]
             .as_array()
             .is_some_and(|files| files.iter().any(|path| path == "lib/aaa_runtime.rb")),
@@ -2382,6 +2402,34 @@ fn pdg_slice_selection_filters_generic_ruby_dynamic_runtime_noise() {
             .expect("serialize slice_selection")
             .contains("lib/aaa_runtime.rb"),
         "unexpected generic dynamic runtime leaked into slice_selection explanation context: {prop:#}"
+    );
+
+    let runtime_witness =
+        &prop["impacted_witnesses"]["ruby:lib/route_runtime.rb:method:method_missing:2"];
+    assert_eq!(
+        witness_slice_paths(runtime_witness),
+        vec!["app/runner.rb", "lib/service.rb", "lib/route_runtime.rb"],
+        "expected duplicate runtime losers to keep witness scope pinned to the selected runtime path: {prop:#}"
+    );
+    let route_runtime_context = witness_slice_file(runtime_witness, "lib/route_runtime.rb");
+    assert!(
+        route_runtime_context
+            .as_object()
+            .is_some_and(|file| !file.contains_key("selected_vs_pruned_reasons")),
+        "expected same-path duplicate losers to stay folded into the selected runtime path instead of widening witness reasoning: {prop:#}"
+    );
+
+    let service_witness = &prop["impacted_witnesses"]["ruby:lib/service.rb:method:bounce:4"];
+    assert_eq!(
+        witness_slice_paths(service_witness),
+        vec!["app/runner.rb", "lib/service.rb"],
+        "expected same-path duplicate runtime losers to stay out of upstream witness scope: {prop:#}"
+    );
+    assert!(
+        !serde_json::to_string(&service_witness["slice_context"])
+            .expect("serialize service witness slice_context")
+            .contains("lib/route_runtime.rb"),
+        "unexpected selected runtime path leaked into upstream witness explanation scope: {prop:#}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add CLI regressions that prove G10 same-family and same-path pruning stays out of witness/slice explanation scope
- add an impact unit test that keeps same-path duplicates and bridge-budget drops out of selected-vs-pruned witness reasoning
- lock the new precision wins as compact, non-widening behavior rather than broader slice growth

## Testing
- cargo test --offline
- cargo clippy --offline
