### PR TITLE
docs: add G11 PDG failure eval set

### DIFF
--- a/docs/g11-2-pdg-failure-eval-set.json
+++ b/docs/g11-2-pdg-failure-eval-set.json
@@ -1,0 +1,286 @@
+{
+  "generated_by": "manual G11-2 design note",
+  "repo_root": "/home/shioriko/src/github.com/n01e0/dimpact",
+  "purpose": "fixed current-main failure set for multi-file PDG / propagation continuation work",
+  "context": {
+    "supersedes_focus": "docs/g4-2-pdg-multi-file-eval-set.md",
+    "paired_design_note": "docs/g11-1-pdg-scope-bridge-expansion-memo.md",
+    "selection_basis": [
+      "reproducible on current main",
+      "targets current bounded-frontier / propagation limits instead of older direct-boundary misses",
+      "shapes are small enough to become fixtures/regressions in later G11 tasks"
+    ]
+  },
+  "defaults": {
+    "engine": "ts",
+    "lanes": [
+      "baseline",
+      "pdg",
+      "propagation"
+    ],
+    "note": "keep engine-difference evaluation out of this set; this set isolates current PDG scope / propagation failure modes"
+  },
+  "cases": [
+    {
+      "case_id": "rust-two-hop-wrapper-return-continuation",
+      "lang": "rust",
+      "failure_kind": "fn",
+      "primary_view": "dot",
+      "focus": "caller result should recover a two-hop wrapper-return continuation across wrap -> step -> leaf",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--engine",
+          "ts",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "dot"
+        ]
+      },
+      "repro": {
+        "layout": [
+          "main.rs",
+          "wrap.rs",
+          "step.rs",
+          "leaf.rs"
+        ],
+        "initial_source": {
+          "main.rs": "mod wrap;\nmod step;\nmod leaf;\nfn caller() {\n    let x = 1;\n    let y = wrap::wrap(x);\n    println!(\"{}\", y);\n}\n",
+          "wrap.rs": "pub fn wrap(a: i32) -> i32 {\n    crate::step::step(a)\n}\n",
+          "step.rs": "pub fn step(a: i32) -> i32 {\n    let v = crate::leaf::leaf(a);\n    v + 1\n}\n",
+          "leaf.rs": "pub fn leaf(a: i32) -> i32 { a + 1 }\n"
+        },
+        "mutation": {
+          "file": "main.rs",
+          "replace": "let x = 1;",
+          "with": "let x = 2;"
+        }
+      },
+      "observed_on_current_main": {
+        "present": [
+          "step.rs:def:v:2",
+          "rust:wrap.rs:fn:wrap:1 -> main.rs:def:y:6"
+        ],
+        "absent": [
+          "main.rs:use:x:6 -> main.rs:def:y:6",
+          "leaf.rs:def:a:1"
+        ]
+      },
+      "why_it_matters": "current propagation already handles direct boundary plus one-hop completion; this case fixes the next frontier where continuation needs two inter-file hops before it can explain the caller result"
+    },
+    {
+      "case_id": "rust-nested-two-arg-summary-continuation",
+      "lang": "rust",
+      "failure_kind": "fn",
+      "primary_view": "dot",
+      "focus": "relevant second argument should survive a nested multi-input continuation through wrap -> pair",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--engine",
+          "ts",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "dot"
+        ]
+      },
+      "repro": {
+        "layout": [
+          "main.rs",
+          "wrap.rs",
+          "pair.rs"
+        ],
+        "initial_source": {
+          "main.rs": "mod wrap;\nmod pair;\nfn caller() {\n    let x = 1;\n    let y = 2;\n    let out = wrap::wrap(x, y);\n    println!(\"{}\", out);\n}\n",
+          "wrap.rs": "pub fn wrap(a: i32, b: i32) -> i32 {\n    let v = crate::pair::pair(a, b);\n    v + 1\n}\n",
+          "pair.rs": "pub fn pair(a: i32, b: i32) -> i32 { b + 1 }\n"
+        },
+        "mutation": {
+          "file": "main.rs",
+          "replace": "let y = 2;",
+          "with": "let y = 3;"
+        }
+      },
+      "observed_on_current_main": {
+        "present": [
+          "pair.rs:def:b:1",
+          "wrap.rs:def:v:2",
+          "wrap.rs:use:b:2 -> wrap.rs:def:v:2"
+        ],
+        "absent": [
+          "main.rs:use:y:6 -> main.rs:def:out:6"
+        ]
+      },
+      "why_it_matters": "single-file two-arg FP guards already exist, but nested multi-input continuation is still weak; this case isolates the missing step without conflating it with direct-boundary scope selection"
+    },
+    {
+      "case_id": "rust-cross-file-wrapper-return-alias-chain",
+      "lang": "rust",
+      "failure_kind": "fn",
+      "primary_view": "dot",
+      "focus": "imported result should flow through wrapper-local alias chain and return to caller result",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--engine",
+          "ts",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "dot"
+        ]
+      },
+      "repro": {
+        "layout": [
+          "main.rs",
+          "wrap.rs",
+          "value.rs"
+        ],
+        "initial_source": {
+          "main.rs": "mod wrap;\nmod value;\nfn caller() {\n    let x = 1;\n    let out = wrap::wrap(x);\n    println!(\"{}\", out);\n}\n",
+          "wrap.rs": "pub fn wrap(a: i32) -> i32 {\n    let y = crate::value::make(a);\n    let alias = y;\n    alias\n}\n",
+          "value.rs": "pub fn make(a: i32) -> i32 { a + 1 }\n"
+        },
+        "mutation": {
+          "file": "main.rs",
+          "replace": "let x = 1;",
+          "with": "let x = 2;"
+        }
+      },
+      "observed_on_current_main": {
+        "present": [
+          "wrap.rs:def:y:2 -> wrap.rs:def:alias:3",
+          "value.rs:def:a:1"
+        ],
+        "absent": [
+          "main.rs:use:x:5 -> main.rs:def:out:5"
+        ]
+      },
+      "why_it_matters": "this is the smallest current-main case where return continuation and alias continuation interact; direct imported-result stitching works inside the wrapper, but it still does not naturally close back at the caller"
+    },
+    {
+      "case_id": "ruby-two-hop-require-relative-return-continuation",
+      "lang": "ruby",
+      "failure_kind": "fn",
+      "primary_view": "dot",
+      "focus": "require_relative split should recover a two-hop return continuation across wrap -> step -> leaf",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--engine",
+          "ts",
+          "--lang",
+          "ruby",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "dot"
+        ]
+      },
+      "repro": {
+        "layout": [
+          "main.rb",
+          "lib/wrap.rb",
+          "lib/step.rb",
+          "lib/leaf.rb"
+        ],
+        "initial_source": {
+          "main.rb": "require_relative \"lib/wrap\"\n\ndef entry\n  x = 1\n  y = Wrap.wrap(x)\n  puts y\nend\n",
+          "lib/wrap.rb": "require_relative \"step\"\n\nmodule Wrap\n  def self.wrap(a)\n    Step.step(a)\n  end\nend\n",
+          "lib/step.rb": "require_relative \"leaf\"\n\nmodule Step\n  def self.step(a)\n    v = Leaf.leaf(a)\n    v + 1\n  end\nend\n",
+          "lib/leaf.rb": "module Leaf\n  def self.leaf(a)\n    a + 1\n  end\nend\n"
+        },
+        "mutation": {
+          "file": "main.rb",
+          "replace": "x = 1",
+          "with": "x = 2"
+        }
+      },
+      "observed_on_current_main": {
+        "present": [
+          "lib/step.rb:def:v:5",
+          "ruby:lib/leaf.rb:method:leaf:2"
+        ],
+        "absent": [
+          "main.rb:use:x:4 -> main.rb:def:y:4",
+          "lib/leaf.rb:def:a:3"
+        ]
+      },
+      "why_it_matters": "direct Ruby require_relative success cases already exist, but this keeps the current frontier honest: Ruby still weakens once continuation must cross two file boundaries before returning to the caller"
+    },
+    {
+      "case_id": "rust-three-boundary-bridge-budget-overflow",
+      "lang": "rust",
+      "failure_kind": "fn_scope",
+      "primary_view": "json",
+      "focus": "bounded slice planner should not drop a third semantically valid leaf only because per-seed tier2 budget is exhausted",
+      "direction": "callees",
+      "lanes": {
+        "propagation": [
+          "impact",
+          "--engine",
+          "ts",
+          "--direction",
+          "callees",
+          "--with-propagation",
+          "--format",
+          "json",
+          "--with-edges"
+        ]
+      },
+      "repro": {
+        "layout": [
+          "main.rs",
+          "a_wrapper.rs",
+          "a_leaf.rs",
+          "b_wrapper.rs",
+          "b_leaf.rs",
+          "c_wrapper.rs",
+          "c_leaf.rs"
+        ],
+        "initial_source": {
+          "main.rs": "mod a_wrapper;\nmod a_leaf;\nmod b_wrapper;\nmod b_leaf;\nmod c_wrapper;\nmod c_leaf;\n\nfn caller() {\n    let x = 1;\n    let ya = a_wrapper::wrap_a(x);\n    let yb = b_wrapper::wrap_b(x);\n    let yc = c_wrapper::wrap_c(x);\n    println!(\"{} {} {}\", ya, yb, yc);\n}\n",
+          "a_wrapper.rs": "pub fn wrap_a(a: i32) -> i32 {\n    crate::a_leaf::leaf_a(a)\n}\n",
+          "a_leaf.rs": "pub fn leaf_a(a: i32) -> i32 { a + 1 }\n",
+          "b_wrapper.rs": "pub fn wrap_b(a: i32) -> i32 {\n    crate::b_leaf::leaf_b(a)\n}\n",
+          "b_leaf.rs": "pub fn leaf_b(a: i32) -> i32 { a + 2 }\n",
+          "c_wrapper.rs": "pub fn wrap_c(a: i32) -> i32 {\n    crate::c_leaf::leaf_c(a)\n}\n",
+          "c_leaf.rs": "pub fn leaf_c(a: i32) -> i32 { a + 3 }\n"
+        },
+        "mutation": {
+          "file": "main.rs",
+          "replace": "let x = 1;",
+          "with": "let x = 2;"
+        }
+      },
+      "observed_on_current_main": {
+        "selected_files": [
+          "a_leaf.rs",
+          "a_wrapper.rs",
+          "b_leaf.rs",
+          "b_wrapper.rs",
+          "c_wrapper.rs",
+          "main.rs"
+        ],
+        "pruned_candidates": [
+          {
+            "path": "c_leaf.rs",
+            "prune_reason": "bridge_budget_exhausted",
+            "via_symbol_id": "rust:c_wrapper.rs:fn:wrap_c:1"
+          }
+        ]
+      },
+      "why_it_matters": "G11 is about bounded slices, not unbounded growth, but the current budget is still crude; this case fixes a concrete planner failure where the third valid leaf loses for purely budgetary reasons"
+    }
+  ]
+}

--- a/docs/g11-2-pdg-failure-eval-set.md
+++ b/docs/g11-2-pdg-failure-eval-set.md
@@ -1,0 +1,528 @@
+# G11-2: current multi-file PDG failure fixed evaluation set
+
+このメモは、G11 で戻り先にする **current main 向け fixed evaluation set** を決めるためのもの。
+
+G4-2 では「multi-file にした時に弱くなりやすい代表ケース」を固定した。
+ただ、main の PDG path はその後かなり進んでいる。
+
+- bounded slice planner が入った
+- `slice_selection_summary` / `pruned_candidates` が出るようになった
+- direct boundary の cross-file summary bridge は既に一部回収できている
+- Ruby の require_relative fallback も、少なくとも 1-hop の代表ケースは guard/test がある
+
+そのため G11-2 では、昔の「multi-file にすると弱い」をそのままなぞるのではなく、
+**main でまだ落ちている failure case** に寄せて fixed set を組み直す。
+
+選定基準は次の 3 つ。
+
+1. **current main で再現すること**
+2. 既存の direct-boundary success case ではなく、**今の bounded frontier / propagation の限界**を踏むこと
+3. 後続 task で docs / tests / code に落としやすいこと
+
+今回の set では **5 ケース** を採用する。
+
+- Rust: 4 ケース
+- Ruby: 1 ケース
+
+machine-readable set: `docs/g11-2-pdg-failure-eval-set.json`
+
+---
+
+## 1. この set で見たい failure family
+
+G11-2 で固定したい failure family は、次の 5 種類。
+
+1. **one-hop completion では足りない wrapper-return continuation**
+2. **nested callee が multi-input になると summary continuation が痩せる問題**
+3. **wrapper 内 alias chain までは見えるのに caller result へ戻り切れない問題**
+4. **Ruby require_relative split で 2-hop continuation が閉じない問題**
+5. **bridge completion budget により、妥当な leaf が slice から落ちる問題**
+
+ここで重要なのは、G11 の主論点がもう
+
+- 「callee file を scope に入れられるか」
+
+だけではないこと。
+
+main の実装では、direct boundary file の取り込み自体はかなり前進している。
+いま本当に弱いのは、
+
+- その先の continuation をどこまで閉じるか
+- multi-input / alias / two-hop のどれを bridge family として扱えるか
+- bounded planner の budget と propagation の bridge 形成がどこで頭打ちになるか
+
+である。
+
+---
+
+## 2. 固定ルール
+
+## 2.1 lane
+
+この set の比較 lane は次で固定する。
+
+- baseline: 通常 impact path
+- pdg: `--with-pdg`
+- propagation: `--with-propagation`
+
+ただし全ケースで baseline を主比較にする必要はない。
+current frontier は多くが
+**PDG はある程度動くが propagation / continuation が最後まで閉じない**
+という形なので、case ごとに primary lane を固定する。
+
+## 2.2 engine
+
+G11-2 の主題は engine 差分ではない。
+したがって engine は G4-2 と同様に、まず安定面として `ts` に固定する。
+
+- `--engine ts`
+- `auto-policy` / strict LSP 差分はこの set では扱わない
+
+## 2.3 primary view
+
+観測の主画面は case ごとに次を使い分ける。
+
+- **bridge そのもの**を見たい: `-f dot`
+- **slice selection / pruned candidate** を見たい: `-f json --with-edges`
+- 必要なら両方を見る
+
+## 2.4 current-main 再現の扱い
+
+この set は「理論上弱そう」な case 集ではなく、
+**main で実際に落ちる shape** を固定する set とする。
+
+したがって各 case には
+
+- repro layout
+- mutation
+- primary command
+- main で観測した gap
+
+を最低限残す。
+
+---
+
+## 3. 採用ケース一覧
+
+| case_id | lang | failure kind | primary view | ねらい |
+| --- | --- | --- | --- | --- |
+| rust-two-hop-wrapper-return-continuation | rust | FN | dot | `main -> wrap -> step -> leaf` の 2-hop continuation が caller result まで戻らない |
+| rust-nested-two-arg-summary-continuation | rust | FN | dot | nested callee が 2 引数になると relevant arg continuation が caller result に戻らない |
+| rust-cross-file-wrapper-return-alias-chain | rust | FN | dot | wrapper 内 alias chain は見えるが imported result が caller result まで閉じない |
+| ruby-two-hop-require-relative-return-continuation | ruby | FN | dot | `main -> wrap -> step -> leaf` の require_relative split で 2-hop continuation が閉じない |
+| rust-three-boundary-bridge-budget-overflow | rust | FN/scope | json | 3 つの boundary があると per-seed Tier2 budget で 1 つが落ちる |
+
+---
+
+## 4. 各ケースの固定意図
+
+## 4.1 `rust-two-hop-wrapper-return-continuation`
+
+### Layout
+
+- `main.rs`
+- `wrap.rs`
+- `step.rs`
+- `leaf.rs`
+
+```rust
+// main.rs
+mod wrap;
+mod step;
+mod leaf;
+fn caller() {
+    let x = 1;
+    let y = wrap::wrap(x);
+    println!("{}", y);
+}
+```
+
+```rust
+// wrap.rs
+pub fn wrap(a: i32) -> i32 {
+    crate::step::step(a)
+}
+```
+
+```rust
+// step.rs
+pub fn step(a: i32) -> i32 {
+    let v = crate::leaf::leaf(a);
+    v + 1
+}
+```
+
+```rust
+// leaf.rs
+pub fn leaf(a: i32) -> i32 { a + 1 }
+```
+
+mutation は `main.rs` の `let x = 1;` → `let x = 2;` に固定する。
+
+### Primary command
+
+```bash
+git diff --no-ext-diff --unified=0 | \
+  dimpact impact --engine ts --direction callees --with-propagation --format dot
+```
+
+### Why this case
+
+main の propagation は direct boundary + one-hop completion までは持っている。
+しかしこの shape は
+
+- `main -> wrap`
+- `wrap -> step`
+- `step -> leaf`
+
+と **return continuation が 2 hop** 必要になる。
+
+現在の実装では `step.rs:def:v` は見えても、caller 側の `use(x) -> def(y)` へ最後まで戻り切れない。
+`leaf.rs` 側 local node も raw call symbol に比べると弱い。
+
+### Current main observation
+
+current main では次が見える。
+
+- `step.rs:def:v:2` は出る
+- `rust:wrap.rs:fn:wrap:1 -> main.rs:def:y:6` は出る
+- `main.rs:use:x:6 -> main.rs:def:y:6` は出ない
+- `leaf.rs:def:a:1` も出ない
+
+### What later success looks like
+
+- propagation lane で caller 側 `use(x)` から `def(y)` まで bridge が戻る
+- `leaf.rs` 側 node / witness も completion の一部として見える
+
+---
+
+## 4.2 `rust-nested-two-arg-summary-continuation`
+
+### Layout
+
+- `main.rs`
+- `wrap.rs`
+- `pair.rs`
+
+```rust
+// main.rs
+mod wrap;
+mod pair;
+fn caller() {
+    let x = 1;
+    let y = 2;
+    let out = wrap::wrap(x, y);
+    println!("{}", out);
+}
+```
+
+```rust
+// wrap.rs
+pub fn wrap(a: i32, b: i32) -> i32 {
+    let v = crate::pair::pair(a, b);
+    v + 1
+}
+```
+
+```rust
+// pair.rs
+pub fn pair(a: i32, b: i32) -> i32 { b + 1 }
+```
+
+mutation は `main.rs` の `let y = 2;` → `let y = 3;` に固定する。
+
+### Primary command
+
+```bash
+git diff --no-ext-diff --unified=0 | \
+  dimpact impact --engine ts --direction callees --with-propagation --format dot
+```
+
+### Why this case
+
+single-file の 2 引数 case には既に FP guard がある。
+しかし current frontier は、
+**nested callee が multi-input になったときの continuation** である。
+
+この shape では caller 側の relevant arg は `y` で、
+`wrap` 内には `v` があり、`pair` 側では `b` が効く。
+
+現在の propagation は nested completion を持つが、
+summary mapping が multi-input nested case で最後まで閉じない。
+
+### Current main observation
+
+current main では次が見える。
+
+- `pair.rs:def:b:1` は出る
+- `wrap.rs:def:v:2` は出る
+- `wrap.rs:use:b:2 -> wrap.rs:def:v:2` は出る
+- `main.rs:use:y:6 -> main.rs:def:out:6` は出ない
+
+### What later success looks like
+
+- relevant arg `y` だけが `out` まで戻る
+- irrelevant arg `x` を巻き込まずに multi-input nested continuation を回収できる
+
+---
+
+## 4.3 `rust-cross-file-wrapper-return-alias-chain`
+
+### Layout
+
+- `main.rs`
+- `wrap.rs`
+- `value.rs`
+
+```rust
+// main.rs
+mod wrap;
+mod value;
+fn caller() {
+    let x = 1;
+    let out = wrap::wrap(x);
+    println!("{}", out);
+}
+```
+
+```rust
+// wrap.rs
+pub fn wrap(a: i32) -> i32 {
+    let y = crate::value::make(a);
+    let alias = y;
+    alias
+}
+```
+
+```rust
+// value.rs
+pub fn make(a: i32) -> i32 { a + 1 }
+```
+
+mutation は `main.rs` の `let x = 1;` → `let x = 2;` に固定する。
+
+### Primary command
+
+```bash
+git diff --no-ext-diff --unified=0 | \
+  dimpact impact --engine ts --direction callees --with-propagation --format dot
+```
+
+### Why this case
+
+これは one-hop continuation より少し嫌らしい。
+
+- imported result `value::make(a)`
+- wrapper 内 temp `y`
+- wrapper 内 alias `alias`
+- caller result `out`
+
+という **return + alias** の複合 shape だから。
+
+current main では wrapper 内の alias chain 自体は見えるが、
+その chain が caller 側 `out` まで自然に閉じない。
+
+### Current main observation
+
+current main では次が見える。
+
+- `wrap.rs:def:y:2 -> wrap.rs:def:alias:3` は出る
+- `value.rs:def:a:1` も出る
+- `main.rs:use:x:5 -> main.rs:def:out:5` は出ない
+
+### What later success looks like
+
+- imported callee result が `y -> alias -> out` まで途切れずに説明できる
+- wrapper 内 alias chain だけで終わらず caller result まで閉じる
+
+---
+
+## 4.4 `ruby-two-hop-require-relative-return-continuation`
+
+### Layout
+
+- `main.rb`
+- `lib/wrap.rb`
+- `lib/step.rb`
+- `lib/leaf.rb`
+
+```ruby
+# main.rb
+require_relative "lib/wrap"
+
+def entry
+  x = 1
+  y = Wrap.wrap(x)
+  puts y
+end
+```
+
+```ruby
+# lib/wrap.rb
+require_relative "step"
+
+module Wrap
+  def self.wrap(a)
+    Step.step(a)
+  end
+end
+```
+
+```ruby
+# lib/step.rb
+require_relative "leaf"
+
+module Step
+  def self.step(a)
+    v = Leaf.leaf(a)
+    v + 1
+  end
+end
+```
+
+```ruby
+# lib/leaf.rb
+module Leaf
+  def self.leaf(a)
+    a + 1
+  end
+end
+```
+
+mutation は `main.rb` の `x = 1` → `x = 2` に固定する。
+
+### Primary command
+
+```bash
+git diff --no-ext-diff --unified=0 | \
+  dimpact impact --engine ts --lang ruby --direction callees --with-propagation --format dot
+```
+
+### Why this case
+
+Rust だけでなく Ruby でも、current frontier は direct require_relative success ではなく
+**2-hop continuation** である。
+
+この shape は
+
+- require_relative split
+- wrapper module
+- temp alias `v`
+- downstream leaf
+
+を全部使うので、Ruby 側の continuation の限界をかなり素直に踏む。
+
+### Current main observation
+
+current main では次が見える。
+
+- `lib/step.rb:def:v:5` は出る
+- `ruby:lib/leaf.rb:method:leaf:2` symbol は出る
+- `main.rb:use:x:4 -> main.rb:def:y:4` は出ない
+- `lib/leaf.rb:def:a:3` は出ない
+
+### What later success looks like
+
+- Ruby でも caller 側 `x -> y` の continuation が戻る
+- require_relative split の先の leaf local node まで観測できる
+
+---
+
+## 4.5 `rust-three-boundary-bridge-budget-overflow`
+
+### Layout
+
+- `main.rs`
+- `a_wrapper.rs` / `a_leaf.rs`
+- `b_wrapper.rs` / `b_leaf.rs`
+- `c_wrapper.rs` / `c_leaf.rs`
+
+```rust
+// main.rs
+mod a_wrapper;
+mod a_leaf;
+mod b_wrapper;
+mod b_leaf;
+mod c_wrapper;
+mod c_leaf;
+
+fn caller() {
+    let x = 1;
+    let ya = a_wrapper::wrap_a(x);
+    let yb = b_wrapper::wrap_b(x);
+    let yc = c_wrapper::wrap_c(x);
+    println!("{} {} {}", ya, yb, yc);
+}
+```
+
+各 wrapper は対応する leaf を 1 回だけ呼ぶ最小形にする。
+mutation は `main.rs` の `let x = 1;` → `let x = 2;` に固定する。
+
+### Primary command
+
+```bash
+git diff --no-ext-diff --unified=0 | \
+  dimpact impact --engine ts --direction callees --with-propagation --format json --with-edges
+```
+
+### Why this case
+
+これは pure propagation failure というより、
+**bounded slice planner の budget failure** を固定するケース。
+
+current main は per-seed Tier2 bridge completion を 2 file までに制限している。
+そのため 3 つの boundary が同じ seed から生えると、
+3 個目の leaf は妥当でも slice から落ちる。
+
+### Current main observation
+
+current main の `summary.slice_selection` では次が観測できる。
+
+- selected files: `a_leaf.rs`, `a_wrapper.rs`, `b_leaf.rs`, `b_wrapper.rs`, `c_wrapper.rs`, `main.rs`
+- pruned candidate: `c_leaf.rs`
+- prune reason: `bridge_budget_exhausted`
+- `via_symbol_id`: `rust:c_wrapper.rs:fn:wrap_c:1`
+
+### What later success looks like
+
+- budget の持ち方を bridge family / seed frontier に合わせて見直せる
+- 少なくとも「3 本目だから無条件に落ちる」形からは抜けられる
+
+---
+
+## 5. この set を採用する理由
+
+G11-2 では、あえて direct boundary の success case を中心には置かなかった。
+理由は単純で、そこは main ですでにかなり改善されているから。
+
+いま固定すべきなのは、次のような **current frontier** である。
+
+- one-hop を越える continuation
+- nested multi-input continuation
+- return と alias が混ざる continuation
+- Ruby require_relative split の 2-hop continuation
+- bounded planner の budget failure
+
+この 5 ケースを固定しておくと、後続の G11-3〜G11-7 で
+
+- scope の widening が効いたのか
+- bridge family が増えたのか
+- propagation の continuation が改善したのか
+- それとも budget / ranking の見直しが必要なのか
+
+を比較しやすい。
+
+---
+
+## 6. 次にやること
+
+この set を土台に、後続 task では次の順で進めるのがよい。
+
+1. まず case ごとの repro を tests/fixture に落とす
+2. slice selection summary の expected shape を固定する
+3. propagation edge / witness の before-after を固定する
+4. 最後に README / README_ja の current limits を main 実装に合わせて更新する
+
+要するに G11-2 は、単なるアイデア集ではなく
+**今の main で本当に痛い multi-file PDG 失敗面を固定するための足場**
+である。


### PR DESCRIPTION
## Summary
- add a G11-specific fixed evaluation note for current multi-file PDG / propagation failures
- document five current-main failure shapes, including two-hop continuation gaps, nested multi-arg continuation, wrapper alias return stitching, and bridge-budget overflow
- add a machine-readable JSON companion for follow-up fixture/regression work

## Testing
- validated docs/g11-2-pdg-failure-eval-set.json parses as JSON

Task: G11-2