### PR TITLE
pdg: extend rust two-hop wrapper return propagation

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1415,6 +1415,7 @@ fn collect_ruby_narrow_fallback_candidates(
                 path: candidate_file.clone(),
                 via_symbol_id: boundary_symbol.id.0.clone(),
                 via_path: boundary_file.to_string(),
+                completion_symbol_id: boundary_symbol.id.0.clone(),
                 bridge_kind: None,
                 scoring: ruby_narrow_fallback_scoring_summary(
                     candidate_file.as_str(),
@@ -1454,17 +1455,20 @@ enum SliceSelectionTier {
     Root,
     DirectBoundary,
     BridgeCompletion,
+    BridgeContinuation,
     ModuleCompanionFallback,
 }
 
 const PER_BOUNDARY_SIDE_TIER2_FILES_MAX: usize = 1;
 const PER_SEED_TIER2_FILES_MAX: usize = 2;
+const PER_SEED_TIER3_FILES_MAX: usize = 1;
 
 fn slice_selection_tier_value(tier: SliceSelectionTier) -> u8 {
     match tier {
         SliceSelectionTier::Root => 0,
         SliceSelectionTier::DirectBoundary => 1,
         SliceSelectionTier::BridgeCompletion => 2,
+        SliceSelectionTier::BridgeContinuation => 3,
         SliceSelectionTier::ModuleCompanionFallback => 3,
     }
 }
@@ -1488,6 +1492,7 @@ struct Tier2Candidate {
     path: String,
     via_symbol_id: String,
     via_path: String,
+    completion_symbol_id: String,
     bridge_kind: Option<ImpactSliceBridgeKind>,
     scoring: ImpactSliceCandidateScoringSummary,
 }
@@ -2012,19 +2017,38 @@ fn candidate_tier(candidate: &Tier2Candidate) -> SliceSelectionTier {
     }
 }
 
-fn make_tier2_reason(
+fn make_candidate_reason_with_tier(
     seed_symbol_id: &str,
     candidate: &Tier2Candidate,
+    tier: SliceSelectionTier,
 ) -> ImpactSliceReasonMetadata {
     ImpactSliceReasonMetadata {
         seed_symbol_id: seed_symbol_id.to_string(),
-        tier: slice_selection_tier_value(candidate_tier(candidate)),
+        tier: slice_selection_tier_value(tier),
         kind: candidate_reason_kind(candidate),
         via_symbol_id: Some(candidate.via_symbol_id.clone()),
         via_path: Some(candidate.via_path.clone()),
         bridge_kind: candidate.bridge_kind,
         scoring: Some(candidate.scoring.clone()),
     }
+}
+
+fn make_tier2_reason(
+    seed_symbol_id: &str,
+    candidate: &Tier2Candidate,
+) -> ImpactSliceReasonMetadata {
+    make_candidate_reason_with_tier(seed_symbol_id, candidate, candidate_tier(candidate))
+}
+
+fn make_continuation_reason(
+    seed_symbol_id: &str,
+    candidate: &Tier2Candidate,
+) -> ImpactSliceReasonMetadata {
+    make_candidate_reason_with_tier(
+        seed_symbol_id,
+        candidate,
+        SliceSelectionTier::BridgeContinuation,
+    )
 }
 
 fn make_tier2_pruned_candidate(
@@ -2194,6 +2218,132 @@ fn suppress_weaker_same_family_rust_siblings(
     admitted
 }
 
+fn continuation_ready_rust_wrapper_return_anchor(candidate: &Tier2Candidate) -> bool {
+    candidate.scoring.source_kind == ImpactSliceCandidateSourceKind::GraphSecondHop
+        && candidate.bridge_kind == Some(ImpactSliceBridgeKind::WrapperReturn)
+        && candidate.path.ends_with(".rs")
+}
+
+fn collect_bridge_continuation_candidates<'a>(
+    seed_symbol_id: &str,
+    seed_selection: &mut SliceSelectionAccumulator,
+    root_file: &str,
+    direct_boundary_paths: &std::collections::BTreeSet<String>,
+    selected_tier2_paths: &std::collections::BTreeSet<String>,
+    anchors: &[Tier2Candidate],
+    symbol_file_by_id: &std::collections::HashMap<String, &'a str>,
+    symbol_by_id: &std::collections::HashMap<String, &'a dimpact::Symbol>,
+    refs: &[Reference],
+    direction: ImpactDirection,
+    tier2_semantic_evidence_by_symbol_id: &mut std::collections::HashMap<
+        String,
+        Tier2SemanticEvidence,
+    >,
+) -> Vec<Tier2Candidate> {
+    let mut continuation_candidates = Vec::new();
+
+    for anchor in anchors
+        .iter()
+        .filter(|candidate| continuation_ready_rust_wrapper_return_anchor(candidate))
+    {
+        let Some(anchor_symbol) = symbol_by_id.get(&anchor.completion_symbol_id).copied() else {
+            continue;
+        };
+        let anchor_file = anchor.path.as_str();
+        let side_refs: Vec<_> = refs
+            .iter()
+            .filter(|r| is_call_graph_ref(r))
+            .filter_map(|reference| {
+                let continuation_symbol_id = match direction {
+                    ImpactDirection::Callers if reference.to.0 == anchor.completion_symbol_id => {
+                        Some(reference.from.0.as_str())
+                    }
+                    ImpactDirection::Callees if reference.from.0 == anchor.completion_symbol_id => {
+                        Some(reference.to.0.as_str())
+                    }
+                    ImpactDirection::Both => {
+                        if reference.to.0 == anchor.completion_symbol_id {
+                            Some(reference.from.0.as_str())
+                        } else if reference.from.0 == anchor.completion_symbol_id {
+                            Some(reference.to.0.as_str())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }?;
+                let continuation_file = symbol_file_by_id.get(continuation_symbol_id).copied()?;
+                if continuation_file == root_file
+                    || continuation_file == anchor_file
+                    || continuation_file == anchor.via_path
+                {
+                    return None;
+                }
+                if direct_boundary_paths.contains(continuation_file)
+                    || selected_tier2_paths.contains(continuation_file)
+                {
+                    return None;
+                }
+                Some((
+                    continuation_symbol_id.to_string(),
+                    continuation_file,
+                    reference.line,
+                ))
+            })
+            .collect();
+        let side_max_call_line = side_refs
+            .iter()
+            .map(|(_, _, line)| *line)
+            .max()
+            .unwrap_or_default();
+
+        let mut per_anchor = std::collections::BTreeMap::new();
+        for (continuation_symbol_id, continuation_file, call_line) in side_refs {
+            let Some(continuation_symbol) = symbol_by_id.get(&continuation_symbol_id).copied()
+            else {
+                continue;
+            };
+            let semantic_evidence = tier2_semantic_evidence_by_symbol_id
+                .entry(continuation_symbol_id.clone())
+                .or_insert_with(|| collect_rust_tier2_semantic_evidence(continuation_symbol))
+                .clone();
+            let scoring = tier2_scoring_summary(
+                anchor_symbol,
+                anchor_file,
+                continuation_symbol,
+                continuation_file,
+                call_line,
+                side_max_call_line,
+                &semantic_evidence,
+            );
+            let bridge_kind = tier2_bridge_kind_for_lane(scoring.lane);
+            if bridge_kind != anchor.bridge_kind {
+                continue;
+            }
+            let candidate = Tier2Candidate {
+                path: continuation_file.to_string(),
+                via_symbol_id: anchor.completion_symbol_id.clone(),
+                via_path: anchor.path.clone(),
+                completion_symbol_id: continuation_symbol_id,
+                bridge_kind,
+                scoring,
+            };
+            record_same_path_candidate(&mut per_anchor, seed_selection, seed_symbol_id, candidate);
+        }
+
+        let mut per_anchor = suppress_before_admit(
+            seed_symbol_id,
+            seed_selection,
+            per_anchor.into_values().collect(),
+        );
+        per_anchor.sort_by(compare_tier2_candidates);
+        continuation_candidates.extend(per_anchor.into_iter().take(1));
+    }
+
+    continuation_candidates.sort_by(compare_tier2_candidates);
+    continuation_candidates
+}
+
 fn plan_bounded_slice(
     cache_update_roots: &[String],
     local_dfg_roots: &[String],
@@ -2336,6 +2486,7 @@ fn plan_bounded_slice(
                     path: completion_file.to_string(),
                     via_symbol_id: boundary.symbol_id.clone(),
                     via_path: boundary_file.to_string(),
+                    completion_symbol_id: completion_symbol_id.clone(),
                     bridge_kind: tier2_bridge_kind_for_lane(scoring.lane),
                     scoring,
                 };
@@ -2390,6 +2541,7 @@ fn plan_bounded_slice(
 
         tier2_candidates.sort_by(compare_tier2_candidates);
         let mut selected_tier2_paths = std::collections::BTreeSet::new();
+        let mut admitted_tier2_candidates = Vec::new();
         for candidate in tier2_candidates {
             if selected_tier2_paths.contains(&candidate.path) {
                 seed_selection.add_reason(
@@ -2410,7 +2562,45 @@ fn plan_bounded_slice(
                 candidate.path.as_str(),
                 make_tier2_reason(seed.id.0.as_str(), &candidate),
             );
-            selected_tier2_paths.insert(candidate.path);
+            selected_tier2_paths.insert(candidate.path.clone());
+            admitted_tier2_candidates.push(candidate);
+        }
+
+        let continuation_candidates = collect_bridge_continuation_candidates(
+            seed.id.0.as_str(),
+            &mut seed_selection,
+            root_file,
+            &direct_boundary_paths,
+            &selected_tier2_paths,
+            &admitted_tier2_candidates,
+            &symbol_file_by_id,
+            &symbol_by_id,
+            refs,
+            direction,
+            &mut tier2_semantic_evidence_by_symbol_id,
+        );
+        let mut selected_continuation_paths = std::collections::BTreeSet::new();
+        for candidate in continuation_candidates {
+            if selected_continuation_paths.contains(&candidate.path) {
+                seed_selection.add_reason(
+                    candidate.path.as_str(),
+                    make_continuation_reason(seed.id.0.as_str(), &candidate),
+                );
+                continue;
+            }
+            if selected_continuation_paths.len() >= PER_SEED_TIER3_FILES_MAX {
+                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                    seed.id.0.as_str(),
+                    &candidate,
+                    ImpactSlicePruneReason::BridgeBudgetExhausted,
+                ));
+                continue;
+            }
+            seed_selection.add_reason(
+                candidate.path.as_str(),
+                make_continuation_reason(seed.id.0.as_str(), &candidate),
+            );
+            selected_continuation_paths.insert(candidate.path);
         }
 
         overall.merge(&seed_selection);

--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -635,7 +635,7 @@ fn push_unique_edge(
     }
 }
 
-fn push_one_hop_completion_bridges(
+fn push_nested_completion_bridges(
     pdg: &mut DataFlowGraph,
     seen_edges: &mut std::collections::HashSet<(String, String, DependencyKind)>,
     outer_callee_id: &str,
@@ -644,8 +644,9 @@ fn push_one_hop_completion_bridges(
     refs: &[Reference],
     summary_by_fn: &std::collections::HashMap<String, FunctionSummary>,
     node_loc_by_id: &std::collections::HashMap<String, (String, u32)>,
+    remaining_hops: usize,
 ) {
-    if callsite_defs.is_empty() {
+    if callsite_defs.is_empty() || remaining_hops == 0 {
         return;
     }
 
@@ -688,6 +689,17 @@ fn push_one_hop_completion_bridges(
                         );
                     }
                 }
+                push_nested_completion_bridges(
+                    pdg,
+                    seen_edges,
+                    nested_ref.to.0.as_str(),
+                    &nested_flow.impacted_node_ids,
+                    callsite_defs,
+                    refs,
+                    summary_by_fn,
+                    node_loc_by_id,
+                    remaining_hops.saturating_sub(1),
+                );
             }
         }
     }
@@ -826,7 +838,7 @@ impl PdgBuilder {
                                 );
                             }
                         }
-                        push_one_hop_completion_bridges(
+                        push_nested_completion_bridges(
                             pdg,
                             &mut seen_edges,
                             r.to.0.as_str(),
@@ -835,6 +847,7 @@ impl PdgBuilder {
                             refs,
                             &summary_by_fn,
                             &node_loc_by_id,
+                            2,
                         );
                         if callsite_defs.len() == 1 {
                             push_unique_edge(
@@ -867,7 +880,7 @@ impl PdgBuilder {
                                 );
                             }
                         }
-                        push_one_hop_completion_bridges(
+                        push_nested_completion_bridges(
                             pdg,
                             &mut seen_edges,
                             r.to.0.as_str(),
@@ -876,6 +889,7 @@ impl PdgBuilder {
                             refs,
                             &summary_by_fn,
                             &node_loc_by_id,
+                            2,
                         );
                     }
                     if callsite_defs.len() == 1 {

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -689,6 +689,77 @@ fn caller() {
     (dir, path)
 }
 
+fn setup_cross_file_two_hop_wrapper_return_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::write(
+        path.join("leaf.rs"),
+        r#"pub fn leaf(a: i32) -> i32 {
+    a + 1
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("step.rs"),
+        r#"use crate::leaf;
+
+pub fn step(a: i32) -> i32 {
+    let v = leaf::leaf(a);
+    v + 1
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("wrap.rs"),
+        r#"use crate::step;
+
+pub fn wrap(a: i32) -> i32 {
+    step::step(a)
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod step;
+mod wrap;
+
+fn caller() {
+    let x = 1;
+    let y = wrap::wrap(x);
+    println!("{}", y);
+}
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod step;
+mod wrap;
+
+fn caller() {
+    let x = 2;
+    let y = wrap::wrap(x);
+    println!("{}", y);
+}
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_cross_file_semantic_support_competition_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -1428,6 +1499,84 @@ fn pdg_propagation_maps_multi_file_wrapper_return_without_leaking_irrelevant_arg
         !prop.contains("\"main.rs:use:x:7\" -> \"main.rs:def:out:7\""),
         "unexpected irrelevant arg bridge leaked through wrapper summary, got:\n{}",
         prop
+    );
+}
+
+#[test]
+fn pdg_propagation_extends_two_hop_wrapper_return_through_rust_bridge_continuation_scope() {
+    let (_tmp, repo) = setup_cross_file_two_hop_wrapper_return_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &["--direction", "callees", "--with-pdg", "--format", "dot"],
+    );
+    let prop = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--with-propagation",
+            "--format",
+            "dot",
+        ],
+    );
+    let prop_json = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--with-propagation",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"leaf.rs:def:a:1\""),
+        "expected bounded slice scope to include continuation leaf DFG nodes in plain PDG, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"main.rs:use:x:7\" -> \"main.rs:def:y:7\""),
+        "plain PDG should still avoid synthesizing the two-hop wrapper return bridge without propagation, got:\n{}",
+        pdg
+    );
+    assert!(
+        prop.contains("\"leaf.rs:use:a:2\" -> \"main.rs:def:y:7\""),
+        "expected propagation to carry the nested leaf return back into the caller result, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"main.rs:use:x:7\" -> \"main.rs:def:y:7\""),
+        "expected propagation to recover the caller-side two-hop wrapper return bridge, got:\n{}",
+        prop
+    );
+
+    let slice_selection = &prop_json["summary"]["slice_selection"];
+    let paths: Vec<&str> = slice_selection["files"]
+        .as_array()
+        .expect("slice_selection.files array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(paths, vec!["leaf.rs", "main.rs", "step.rs", "wrap.rs"]);
+
+    let leaf = slice_selection_file(slice_selection, "leaf.rs");
+    assert!(
+        leaf["reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason["tier"] == 3
+                    && reason["kind"] == "bridge_completion_file"
+                    && reason["via_symbol_id"] == "rust:step.rs:fn:step:3"
+                    && reason["via_path"] == "step.rs"
+                    && reason["bridge_kind"] == "wrapper_return"
+            })),
+        "expected continuation leaf to be explained from the selected step bridge-completion anchor: {prop_json:#}"
     );
 }
 
@@ -2738,15 +2887,21 @@ fn ruby_chain_fixture_only_gains_symbolic_edges_with_propagation() {
         "expected fixed pair of symbolic edges: {prop:#}"
     );
     assert!(prop_edges.iter().all(|e| e["kind"] == "data"));
-    assert!(prop_edges
-        .iter()
-        .all(|e| e["provenance"] == "symbolic_propagation"));
-    assert!(prop_edges
-        .iter()
-        .any(|e| e["to"] == "demo/test.rb:def:v:14"));
-    assert!(prop_edges
-        .iter()
-        .any(|e| e["to"] == "demo/test.rb:use:v:16"));
+    assert!(
+        prop_edges
+            .iter()
+            .all(|e| e["provenance"] == "symbolic_propagation")
+    );
+    assert!(
+        prop_edges
+            .iter()
+            .any(|e| e["to"] == "demo/test.rb:def:v:14")
+    );
+    assert!(
+        prop_edges
+            .iter()
+            .any(|e| e["to"] == "demo/test.rb:use:v:16")
+    );
 }
 
 #[test]
@@ -2967,9 +3122,11 @@ fn ruby_alias_define_fixture_keeps_defined_sym_without_leaking_defined_only() {
     );
     let edges = prop["edges"].as_array().expect("edges array");
 
-    assert!(edges
-        .iter()
-        .any(|e| e["to"] == "ruby:demo/test.rb:method:defined_sym:9"));
+    assert!(
+        edges
+            .iter()
+            .any(|e| e["to"] == "ruby:demo/test.rb:method:defined_sym:9")
+    );
     assert!(
         !edges
             .iter()


### PR DESCRIPTION
## Summary
- extend the bounded Rust PDG slice so an admitted wrapper-return bridge-completion file can add one continuation file
- recurse symbolic completion bridges one more hop so `main -> wrap -> step -> leaf` returns can close back at the caller result
- add a regression covering the new Rust two-hop wrapper-return scope and propagation behavior

## Testing
- cargo test

Task: G11-4