### PR TITLE
pdg: extend ruby require_relative return bridging

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -2218,10 +2218,10 @@ fn suppress_weaker_same_family_rust_siblings(
     admitted
 }
 
-fn continuation_ready_rust_wrapper_return_anchor(candidate: &Tier2Candidate) -> bool {
+fn continuation_ready_wrapper_return_anchor(candidate: &Tier2Candidate) -> bool {
     candidate.scoring.source_kind == ImpactSliceCandidateSourceKind::GraphSecondHop
         && candidate.bridge_kind == Some(ImpactSliceBridgeKind::WrapperReturn)
-        && candidate.path.ends_with(".rs")
+        && (candidate.path.ends_with(".rs") || candidate.path.ends_with(".rb"))
 }
 
 fn collect_bridge_continuation_candidates<'a>(
@@ -2244,7 +2244,7 @@ fn collect_bridge_continuation_candidates<'a>(
 
     for anchor in anchors
         .iter()
-        .filter(|candidate| continuation_ready_rust_wrapper_return_anchor(candidate))
+        .filter(|candidate| continuation_ready_wrapper_return_anchor(candidate))
     {
         let Some(anchor_symbol) = symbol_by_id.get(&anchor.completion_symbol_id).copied() else {
             continue;

--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -901,6 +901,32 @@ impl PdgBuilder {
                             DependencyKind::Data,
                         );
                     }
+                } else if summary.inputs.len() == 1
+                    && callsite_uses.is_empty()
+                    && callsite_defs.len() == 1
+                {
+                    for flow in &active_flows {
+                        for impacted in &flow.impacted_node_ids {
+                            push_unique_edge(
+                                pdg,
+                                &mut seen_edges,
+                                impacted.clone(),
+                                callsite_defs[0].clone(),
+                                DependencyKind::Data,
+                            );
+                        }
+                        push_nested_completion_bridges(
+                            pdg,
+                            &mut seen_edges,
+                            r.to.0.as_str(),
+                            &flow.impacted_node_ids,
+                            &callsite_defs,
+                            refs,
+                            &summary_by_fn,
+                            &node_loc_by_id,
+                            2,
+                        );
+                    }
                 }
             }
         }

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -969,6 +969,80 @@ end
     (dir, path)
 }
 
+fn setup_ruby_two_hop_require_relative_return_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::create_dir_all(path.join("lib")).unwrap();
+    fs::write(
+        path.join("main.rb"),
+        r#"require_relative "lib/wrap"
+
+def entry
+  x = 1
+  y = Wrap.wrap(x)
+  puts y
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/wrap.rb"),
+        r#"require_relative "step"
+
+module Wrap
+  def self.wrap(a)
+    Step.step(a)
+  end
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/step.rb"),
+        r#"require_relative "leaf"
+
+module Step
+  def self.step(a)
+    v = Leaf.leaf(a)
+    v + 1
+  end
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("lib/leaf.rb"),
+        r#"module Leaf
+  def self.leaf(a)
+    a + 1
+  end
+end
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("main.rb"),
+        r#"require_relative "lib/wrap"
+
+def entry
+  x = 2
+  y = Wrap.wrap(x)
+  puts y
+end
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_ruby_require_relative_competing_leaf_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -2292,6 +2366,99 @@ fn pdg_slice_selection_prefers_stronger_rust_semantic_support_over_later_callsit
         plain_paths,
         vec!["main.rs", "wrapper.rs"],
         "expected ranked-out plain.rs witness to stay compact and exclude plain.rs from the explanation slice: {prop:#}"
+    );
+}
+
+#[test]
+fn pdg_propagation_extends_two_hop_require_relative_wrapper_return_scope() {
+    let (_tmp, repo) = setup_ruby_two_hop_require_relative_return_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-pdg",
+            "--format",
+            "dot",
+        ],
+    );
+    let prop = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "dot",
+        ],
+    );
+    let prop_json = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"lib/leaf.rb:def:a:2\""),
+        "expected bounded slice scope to include the two-hop Ruby leaf DFG nodes in plain PDG, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"lib/leaf.rb:use:a:3\" -> \"main.rb:def:y:5\""),
+        "plain PDG should still avoid synthesizing the two-hop Ruby wrapper return bridge without propagation, got:\n{}",
+        pdg
+    );
+    assert!(
+        prop.contains("\"lib/leaf.rb:use:a:3\" -> \"main.rb:def:y:5\""),
+        "expected propagation to carry the nested Ruby leaf return back into the caller result, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"lib/step.rb:use:a:5\" -> \"main.rb:def:y:5\""),
+        "expected propagation to keep the intermediate Ruby step continuation connected to the caller result, got:\n{}",
+        prop
+    );
+
+    let slice_selection = &prop_json["summary"]["slice_selection"];
+    let paths: Vec<&str> = slice_selection["files"]
+        .as_array()
+        .expect("slice_selection.files array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["lib/leaf.rb", "lib/step.rb", "lib/wrap.rb", "main.rb"]
+    );
+
+    let leaf = slice_selection_file(slice_selection, "lib/leaf.rb");
+    assert!(
+        leaf["reasons"]
+            .as_array()
+            .is_some_and(|reasons| reasons.iter().any(|reason| {
+                reason["tier"] == 3
+                    && reason["kind"] == "bridge_completion_file"
+                    && reason["via_symbol_id"] == "ruby:lib/step.rb:method:step:4"
+                    && reason["via_path"] == "lib/step.rb"
+                    && reason["bridge_kind"] == "wrapper_return"
+            })),
+        "expected continuation leaf to be explained from the selected Ruby step bridge-completion anchor: {prop_json:#}"
     );
 }
 


### PR DESCRIPTION
## Summary
- allow bridge-continuation scope selection to extend Ruby wrapper-return anchors as well as Rust ones
- add a single-input propagation fallback that can still carry return-impact into the caller def when Ruby callsite-use capture is missing
- add a Ruby regression for the two-hop `require_relative` wrapper-return case covering both scope selection and propagation

## Testing
- cargo test
- cargo test --test cli_pdg_propagation pdg_propagation_extends_two_hop_require_relative_wrapper_return_scope -- --nocapture

Task: G11-5