### PR TITLE
pdg: relax propagation callsite line attachment

### DIFF
--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -635,6 +635,7 @@ fn push_unique_edge(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_nested_completion_bridges(
     pdg: &mut DataFlowGraph,
     seen_edges: &mut std::collections::HashSet<(String, String, DependencyKind)>,
@@ -703,6 +704,67 @@ fn push_nested_completion_bridges(
             }
         }
     }
+}
+
+fn collect_callsite_nodes(
+    nodes_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    file: &str,
+    line: u32,
+    expected_len: usize,
+    preferred_offsets: &[i32],
+) -> Vec<String> {
+    let mut collected = Vec::new();
+    for offset in preferred_offsets {
+        let candidate_line = if *offset < 0 {
+            let delta = offset.unsigned_abs();
+            if delta > line {
+                continue;
+            }
+            line - delta
+        } else {
+            line.saturating_add(*offset as u32)
+        };
+        let key = (file.to_string(), candidate_line);
+        let Some(node_ids) = nodes_by_loc.get(&key) else {
+            continue;
+        };
+        collected.extend(node_ids.iter().cloned());
+        if expected_len > 0 && collected.len() >= expected_len {
+            break;
+        }
+    }
+    collected
+}
+
+fn collect_callsite_uses(
+    uses_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    file: &str,
+    line: u32,
+    expected_len: usize,
+) -> Vec<String> {
+    let exact = collect_callsite_nodes(uses_by_loc, file, line, expected_len, &[0]);
+    if expected_len == 0 || exact.len() >= expected_len {
+        return exact;
+    }
+    collect_callsite_nodes(
+        uses_by_loc,
+        file,
+        line,
+        expected_len,
+        &[0, 1, -1, 2, -2, 3, -3],
+    )
+}
+
+fn collect_callsite_defs(
+    defs_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    file: &str,
+    line: u32,
+) -> Vec<String> {
+    let exact = collect_callsite_nodes(defs_by_loc, file, line, 0, &[0]);
+    if !exact.is_empty() {
+        return exact;
+    }
+    collect_callsite_nodes(defs_by_loc, file, line, 0, &[0, -1, 1, -2, 2])
 }
 
 impl PdgBuilder {
@@ -774,9 +836,17 @@ impl PdgBuilder {
             r.kind == crate::ir::reference::RefKind::Call
                 && r.provenance == crate::ir::reference::EdgeProvenance::CallGraph
         }) {
-            let key = (r.file.clone(), r.line);
-            let callsite_uses = uses_by_loc.get(&key).cloned().unwrap_or_default();
-            let callsite_defs = defs_by_loc.get(&key).cloned().unwrap_or_default();
+            let summary_input_count = summary_by_fn
+                .get(&r.to.0)
+                .map(|summary| summary.inputs.len())
+                .unwrap_or_default();
+            let callsite_uses = collect_callsite_uses(
+                &uses_by_loc,
+                r.file.as_str(),
+                r.line,
+                summary_input_count.max(1),
+            );
+            let callsite_defs = collect_callsite_defs(&defs_by_loc, r.file.as_str(), r.line);
 
             for u in &callsite_uses {
                 push_unique_edge(
@@ -1020,9 +1090,9 @@ impl PdgBuilder {
                 if !id.contains(":def:") {
                     continue;
                 }
-                if !nodes_by_id
+                if nodes_by_id
                     .get(id.as_str())
-                    .is_some_and(|n| n.line == s.range.start_line)
+                    .is_none_or(|n| n.line != s.range.start_line)
                 {
                     continue;
                 }

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -760,6 +760,66 @@ fn caller() {
     (dir, path)
 }
 
+fn setup_cross_file_multiline_wrapper_return_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::write(
+        path.join("leaf.rs"),
+        r#"pub fn source(v: i32) -> i32 { v + 1 }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("wrapper.rs"),
+        r#"use crate::leaf;
+
+pub fn wrap(v: i32) -> i32 {
+    leaf::source(v)
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod wrapper;
+
+fn caller() {
+    let x = 1;
+    let out = wrapper::wrap(
+        x,
+    );
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("main.rs"),
+        r#"mod leaf;
+mod wrapper;
+
+fn caller() {
+    let x = 2;
+    let out = wrapper::wrap(
+        x,
+    );
+    println!("{}", out);
+}
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_cross_file_semantic_support_competition_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -1651,6 +1711,55 @@ fn pdg_propagation_extends_two_hop_wrapper_return_through_rust_bridge_continuati
                     && reason["bridge_kind"] == "wrapper_return"
             })),
         "expected continuation leaf to be explained from the selected step bridge-completion anchor: {prop_json:#}"
+    );
+}
+
+#[test]
+fn pdg_propagation_recovers_multiline_rust_wrapper_callsite_attachment() {
+    let (_tmp, repo) = setup_cross_file_multiline_wrapper_return_repo();
+    let diff = diff_text(&repo);
+
+    let pdg = run_impact_dot(
+        &repo,
+        &diff,
+        &["--direction", "callees", "--with-pdg", "--format", "dot"],
+    );
+    let prop = run_impact_dot(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callees",
+            "--with-propagation",
+            "--format",
+            "dot",
+        ],
+    );
+
+    assert!(
+        pdg.contains("\"wrapper.rs:def:v:3\""),
+        "expected plain PDG to keep the wrapper param node in scope, got:\n{}",
+        pdg
+    );
+    assert!(
+        !pdg.contains("\"main.rs:use:x:7\" -> \"main.rs:def:out:6\""),
+        "plain PDG should still avoid synthesizing the multiline callsite bridge without propagation, got:\n{}",
+        pdg
+    );
+    assert!(
+        prop.contains("\"main.rs:use:x:7\" -> \"rust:wrapper.rs:fn:wrap:3\""),
+        "expected propagation to attach the off-line caller arg use to the callee symbol, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"main.rs:use:x:7\" -> \"main.rs:def:out:6\""),
+        "expected propagation to recover the caller-side multiline wrapper bridge, got:\n{}",
+        prop
+    );
+    assert!(
+        prop.contains("\"leaf.rs:use:v:1\" -> \"main.rs:def:out:6\""),
+        "expected propagation to keep the downstream return flow attached to the multiline caller def, got:\n{}",
+        prop
     );
 }
 


### PR DESCRIPTION
## Summary
- stop requiring propagation callsite defs/uses to live on the exact call-graph line before attaching summary bridges
- collect caller-side use/def nodes from a small nearby-line window so multiline call expressions can still attach naturally
- add a regression for a multiline Rust wrapper call where the argument use lives on the next line but propagation should still recover the caller bridge

## Testing
- cargo test --offline

Task: G11-6