### PR TITLE
pdg: label continuation slice reasons explicitly

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -1997,12 +1997,19 @@ fn should_suppress_before_admit(
         || candidate_is_weak_ruby_require_relative(candidate)
 }
 
-fn candidate_reason_kind(candidate: &Tier2Candidate) -> ImpactSliceReasonKind {
-    match candidate.scoring.source_kind {
-        ImpactSliceCandidateSourceKind::GraphSecondHop => {
+fn candidate_reason_kind_for_tier(
+    candidate: &Tier2Candidate,
+    tier: SliceSelectionTier,
+) -> ImpactSliceReasonKind {
+    match (candidate.scoring.source_kind, tier) {
+        (
+            ImpactSliceCandidateSourceKind::GraphSecondHop,
+            SliceSelectionTier::BridgeContinuation,
+        ) => ImpactSliceReasonKind::BridgeContinuationFile,
+        (ImpactSliceCandidateSourceKind::GraphSecondHop, _) => {
             ImpactSliceReasonKind::BridgeCompletionFile
         }
-        ImpactSliceCandidateSourceKind::NarrowFallback => {
+        (ImpactSliceCandidateSourceKind::NarrowFallback, _) => {
             ImpactSliceReasonKind::ModuleCompanionFile
         }
     }
@@ -2025,7 +2032,7 @@ fn make_candidate_reason_with_tier(
     ImpactSliceReasonMetadata {
         seed_symbol_id: seed_symbol_id.to_string(),
         tier: slice_selection_tier_value(tier),
-        kind: candidate_reason_kind(candidate),
+        kind: candidate_reason_kind_for_tier(candidate, tier),
         via_symbol_id: Some(candidate.via_symbol_id.clone()),
         via_path: Some(candidate.via_path.clone()),
         bridge_kind: candidate.bridge_kind,
@@ -2051,10 +2058,11 @@ fn make_continuation_reason(
     )
 }
 
-fn make_tier2_pruned_candidate(
+fn make_pruned_candidate_with_tier(
     seed_symbol_id: &str,
     candidate: &Tier2Candidate,
     prune_reason: ImpactSlicePruneReason,
+    tier: SliceSelectionTier,
 ) -> dimpact::ImpactSlicePrunedCandidate {
     let compact_explanation = match prune_reason {
         ImpactSlicePruneReason::SuppressedBeforeAdmit => {
@@ -2078,8 +2086,8 @@ fn make_tier2_pruned_candidate(
     dimpact::ImpactSlicePrunedCandidate {
         seed_symbol_id: seed_symbol_id.to_string(),
         path: candidate.path.clone(),
-        tier: slice_selection_tier_value(candidate_tier(candidate)),
-        kind: candidate_reason_kind(candidate),
+        tier: slice_selection_tier_value(tier),
+        kind: candidate_reason_kind_for_tier(candidate, tier),
         via_symbol_id: Some(candidate.via_symbol_id.clone()),
         via_path: Some(candidate.via_path.clone()),
         bridge_kind: candidate.bridge_kind,
@@ -2089,11 +2097,42 @@ fn make_tier2_pruned_candidate(
     }
 }
 
-fn record_same_path_candidate(
+fn make_tier2_pruned_candidate(
+    seed_symbol_id: &str,
+    candidate: &Tier2Candidate,
+    prune_reason: ImpactSlicePruneReason,
+) -> dimpact::ImpactSlicePrunedCandidate {
+    make_pruned_candidate_with_tier(
+        seed_symbol_id,
+        candidate,
+        prune_reason,
+        candidate_tier(candidate),
+    )
+}
+
+fn make_continuation_pruned_candidate(
+    seed_symbol_id: &str,
+    candidate: &Tier2Candidate,
+    prune_reason: ImpactSlicePruneReason,
+) -> dimpact::ImpactSlicePrunedCandidate {
+    make_pruned_candidate_with_tier(
+        seed_symbol_id,
+        candidate,
+        prune_reason,
+        SliceSelectionTier::BridgeContinuation,
+    )
+}
+
+fn record_same_path_candidate_with_prune(
     side_candidates: &mut std::collections::BTreeMap<String, Tier2Candidate>,
     seed_selection: &mut SliceSelectionAccumulator,
     seed_symbol_id: &str,
     candidate: Tier2Candidate,
+    make_pruned_candidate: impl Fn(
+        &str,
+        &Tier2Candidate,
+        ImpactSlicePruneReason,
+    ) -> dimpact::ImpactSlicePrunedCandidate,
 ) {
     match side_candidates.entry(candidate.path.clone()) {
         std::collections::btree_map::Entry::Vacant(entry) => {
@@ -2102,14 +2141,14 @@ fn record_same_path_candidate(
         std::collections::btree_map::Entry::Occupied(mut entry) => {
             let existing = entry.get().clone();
             if compare_tier2_candidates(&candidate, &existing).is_lt() {
-                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                seed_selection.add_pruned_candidate(make_pruned_candidate(
                     seed_symbol_id,
                     &existing,
                     ImpactSlicePruneReason::WeakerSamePathDuplicate,
                 ));
                 entry.insert(candidate);
             } else {
-                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                seed_selection.add_pruned_candidate(make_pruned_candidate(
                     seed_symbol_id,
                     &candidate,
                     ImpactSlicePruneReason::WeakerSamePathDuplicate,
@@ -2119,10 +2158,45 @@ fn record_same_path_candidate(
     }
 }
 
-fn suppress_before_admit(
+fn record_same_path_candidate(
+    side_candidates: &mut std::collections::BTreeMap<String, Tier2Candidate>,
+    seed_selection: &mut SliceSelectionAccumulator,
+    seed_symbol_id: &str,
+    candidate: Tier2Candidate,
+) {
+    record_same_path_candidate_with_prune(
+        side_candidates,
+        seed_selection,
+        seed_symbol_id,
+        candidate,
+        make_tier2_pruned_candidate,
+    );
+}
+
+fn record_same_path_continuation_candidate(
+    side_candidates: &mut std::collections::BTreeMap<String, Tier2Candidate>,
+    seed_selection: &mut SliceSelectionAccumulator,
+    seed_symbol_id: &str,
+    candidate: Tier2Candidate,
+) {
+    record_same_path_candidate_with_prune(
+        side_candidates,
+        seed_selection,
+        seed_symbol_id,
+        candidate,
+        make_continuation_pruned_candidate,
+    );
+}
+
+fn suppress_before_admit_with_prune(
     seed_symbol_id: &str,
     seed_selection: &mut SliceSelectionAccumulator,
     side_candidates: Vec<Tier2Candidate>,
+    make_pruned_candidate: impl Fn(
+        &str,
+        &Tier2Candidate,
+        ImpactSlicePruneReason,
+    ) -> dimpact::ImpactSlicePrunedCandidate,
 ) -> Vec<Tier2Candidate> {
     let side_has_semantic_ready_candidate = side_candidates
         .iter()
@@ -2131,7 +2205,7 @@ fn suppress_before_admit(
 
     for candidate in side_candidates {
         if should_suppress_before_admit(&candidate, side_has_semantic_ready_candidate) {
-            seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+            seed_selection.add_pruned_candidate(make_pruned_candidate(
                 seed_symbol_id,
                 &candidate,
                 ImpactSlicePruneReason::SuppressedBeforeAdmit,
@@ -2142,6 +2216,32 @@ fn suppress_before_admit(
     }
 
     admitted
+}
+
+fn suppress_before_admit(
+    seed_symbol_id: &str,
+    seed_selection: &mut SliceSelectionAccumulator,
+    side_candidates: Vec<Tier2Candidate>,
+) -> Vec<Tier2Candidate> {
+    suppress_before_admit_with_prune(
+        seed_symbol_id,
+        seed_selection,
+        side_candidates,
+        make_tier2_pruned_candidate,
+    )
+}
+
+fn suppress_before_admit_continuation(
+    seed_symbol_id: &str,
+    seed_selection: &mut SliceSelectionAccumulator,
+    side_candidates: Vec<Tier2Candidate>,
+) -> Vec<Tier2Candidate> {
+    suppress_before_admit_with_prune(
+        seed_symbol_id,
+        seed_selection,
+        side_candidates,
+        make_continuation_pruned_candidate,
+    )
 }
 
 fn rust_same_family_sibling_lane(candidate: &Tier2Candidate) -> Option<ImpactSliceCandidateLane> {
@@ -2224,6 +2324,7 @@ fn continuation_ready_wrapper_return_anchor(candidate: &Tier2Candidate) -> bool 
         && (candidate.path.ends_with(".rs") || candidate.path.ends_with(".rb"))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_bridge_continuation_candidates<'a>(
     seed_symbol_id: &str,
     seed_selection: &mut SliceSelectionAccumulator,
@@ -2328,10 +2429,15 @@ fn collect_bridge_continuation_candidates<'a>(
                 bridge_kind,
                 scoring,
             };
-            record_same_path_candidate(&mut per_anchor, seed_selection, seed_symbol_id, candidate);
+            record_same_path_continuation_candidate(
+                &mut per_anchor,
+                seed_selection,
+                seed_symbol_id,
+                candidate,
+            );
         }
 
-        let mut per_anchor = suppress_before_admit(
+        let mut per_anchor = suppress_before_admit_continuation(
             seed_symbol_id,
             seed_selection,
             per_anchor.into_values().collect(),
@@ -2589,7 +2695,7 @@ fn plan_bounded_slice(
                 continue;
             }
             if selected_continuation_paths.len() >= PER_SEED_TIER3_FILES_MAX {
-                seed_selection.add_pruned_candidate(make_tier2_pruned_candidate(
+                seed_selection.add_pruned_candidate(make_continuation_pruned_candidate(
                     seed.id.0.as_str(),
                     &candidate,
                     ImpactSlicePruneReason::BridgeBudgetExhausted,

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -112,6 +112,7 @@ pub enum ImpactSliceReasonKind {
     DirectCallerFile,
     DirectCalleeFile,
     BridgeCompletionFile,
+    BridgeContinuationFile,
     ModuleCompanionFile,
 }
 
@@ -1087,14 +1088,15 @@ fn selected_reason_matches_pruned_candidate(
     reason: &ImpactSliceReasonMetadata,
     candidate: &ImpactSlicePrunedCandidate,
 ) -> bool {
-    reason.kind == ImpactSliceReasonKind::BridgeCompletionFile
-        && matches!(
-            candidate.prune_reason,
-            ImpactSlicePruneReason::RankedOut
-                | ImpactSlicePruneReason::SuppressedBeforeAdmit
-                | ImpactSlicePruneReason::WeakerSameFamilySibling
-        )
-        && candidate.path != selected_path
+    matches!(
+        reason.kind,
+        ImpactSliceReasonKind::BridgeCompletionFile | ImpactSliceReasonKind::BridgeContinuationFile
+    ) && matches!(
+        candidate.prune_reason,
+        ImpactSlicePruneReason::RankedOut
+            | ImpactSlicePruneReason::SuppressedBeforeAdmit
+            | ImpactSlicePruneReason::WeakerSameFamilySibling
+    ) && candidate.path != selected_path
         && reason.seed_symbol_id == candidate.seed_symbol_id
         && reason.tier == candidate.tier
         && reason.kind == candidate.kind
@@ -3294,6 +3296,88 @@ fn foo() { bar(); }
                 compact_explanation: None,
                 summary: "selected over zzz_final_helper.rs because it had less negative evidence (0 < 1); losing side: negative_evidence=noisy_return_hint".to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn selected_vs_pruned_reason_matches_bridge_continuation_candidates() {
+        let reasons = build_selected_vs_pruned_reasons(
+            "leaf.rs",
+            &[ImpactSliceReasonMetadata {
+                seed_symbol_id: "rust:main.rs:fn:caller:5".to_string(),
+                tier: 3,
+                kind: ImpactSliceReasonKind::BridgeContinuationFile,
+                via_symbol_id: Some("rust:step.rs:fn:step:3".to_string()),
+                via_path: Some("step.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::AssignedResult,
+                        ImpactSliceEvidenceKind::ReturnFlow,
+                    ],
+                    secondary_evidence_kinds: vec![ImpactSliceEvidenceKind::NamePathHint],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 2,
+                        secondary_evidence_count: 1,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 1,
+                        call_position_rank: 5,
+                        lexical_tiebreak: "leaf.rs".to_string(),
+                    },
+                    support: Some(ImpactSliceCandidateSupportMetadata {
+                        local_dfg_support: true,
+                        ..ImpactSliceCandidateSupportMetadata::default()
+                    }),
+                }),
+            }],
+            &[ImpactSlicePrunedCandidate {
+                seed_symbol_id: "rust:main.rs:fn:caller:5".to_string(),
+                path: "alt_leaf.rs".to_string(),
+                tier: 3,
+                kind: ImpactSliceReasonKind::BridgeContinuationFile,
+                via_symbol_id: Some("rust:step.rs:fn:step:3".to_string()),
+                via_path: Some("step.rs".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::WrapperReturn),
+                prune_reason: ImpactSlicePruneReason::RankedOut,
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::ReturnContinuation,
+                    primary_evidence_kinds: vec![ImpactSliceEvidenceKind::AssignedResult],
+                    secondary_evidence_kinds: vec![
+                        ImpactSliceEvidenceKind::CallsitePositionHint,
+                        ImpactSliceEvidenceKind::NamePathHint,
+                    ],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 0,
+                        primary_evidence_count: 1,
+                        secondary_evidence_count: 2,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 6,
+                        lexical_tiebreak: "alt_leaf.rs".to_string(),
+                    },
+                    support: None,
+                }),
+                compact_explanation: None,
+            }],
+        );
+
+        assert_eq!(reasons.len(), 1);
+        assert_eq!(reasons[0].pruned_path, "alt_leaf.rs");
+        assert_eq!(
+            reasons[0].selected_better_by,
+            ImpactWitnessSliceRankingBasis::PrimaryEvidenceCount
+        );
+        assert_eq!(
+            reasons[0].winning_primary_evidence_kinds,
+            Some(vec![ImpactSliceEvidenceKind::ReturnFlow])
         );
     }
 

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1705,7 +1705,7 @@ fn pdg_propagation_extends_two_hop_wrapper_return_through_rust_bridge_continuati
             .as_array()
             .is_some_and(|reasons| reasons.iter().any(|reason| {
                 reason["tier"] == 3
-                    && reason["kind"] == "bridge_completion_file"
+                    && reason["kind"] == "bridge_continuation_file"
                     && reason["via_symbol_id"] == "rust:step.rs:fn:step:3"
                     && reason["via_path"] == "step.rs"
                     && reason["bridge_kind"] == "wrapper_return"
@@ -2562,7 +2562,7 @@ fn pdg_propagation_extends_two_hop_require_relative_wrapper_return_scope() {
             .as_array()
             .is_some_and(|reasons| reasons.iter().any(|reason| {
                 reason["tier"] == 3
-                    && reason["kind"] == "bridge_completion_file"
+                    && reason["kind"] == "bridge_continuation_file"
                     && reason["via_symbol_id"] == "ruby:lib/step.rb:method:step:4"
                     && reason["via_path"] == "lib/step.rb"
                     && reason["bridge_kind"] == "wrapper_return"
@@ -3669,7 +3669,7 @@ fn per_seed_seed_mode_pdg_keeps_two_hop_wrapper_witness_compact() {
             .as_array()
             .is_some_and(|reasons| reasons.iter().any(|reason| {
                 reason["tier"] == 3
-                    && reason["kind"] == "bridge_completion_file"
+                    && reason["kind"] == "bridge_continuation_file"
                     && reason["via_symbol_id"] == "rust:wrap.rs:fn:wrap:3"
                     && reason["bridge_kind"] == "wrapper_return"
             })),
@@ -3800,7 +3800,7 @@ fn per_seed_diff_mode_propagation_keeps_two_hop_wrapper_witness_compact() {
             .as_array()
             .is_some_and(|reasons| reasons.iter().any(|reason| {
                 reason["tier"] == 3
-                    && reason["kind"] == "bridge_completion_file"
+                    && reason["kind"] == "bridge_continuation_file"
                     && reason["via_symbol_id"] == "rust:step.rs:fn:step:3"
                     && reason["via_path"] == "step.rs"
                     && reason["bridge_kind"] == "wrapper_return"
@@ -3930,7 +3930,7 @@ fn per_seed_diff_mode_ruby_two_hop_require_relative_propagation_keeps_compact_wi
             .as_array()
             .is_some_and(|reasons| reasons.iter().any(|reason| {
                 reason["tier"] == 3
-                    && reason["kind"] == "bridge_completion_file"
+                    && reason["kind"] == "bridge_continuation_file"
                     && reason["via_symbol_id"] == "ruby:lib/step.rb:method:step:4"
                     && reason["via_path"] == "lib/step.rb"
                     && reason["bridge_kind"] == "wrapper_return"


### PR DESCRIPTION
## Summary
- distinguish continuation-tier slice metadata from ordinary bridge-completion metadata with a dedicated `bridge_continuation_file` reason kind
- keep selected-vs-pruned witness reasoning aligned by matching continuation-tier pruned candidates against continuation-tier selected reasons
- update the G11 Rust/Ruby regression expectations and add an impact-unit regression for continuation-tier ranking

## Testing
- cargo test --locked --lib selected_vs_pruned_reason_matches_bridge_continuation_candidates -- --nocapture
- cargo test --locked --test cli_pdg_propagation pdg_propagation_extends_two_hop_wrapper_return_through_rust_bridge_continuation_scope -- --nocapture
- cargo test --locked --test cli_pdg_propagation pdg_propagation_extends_two_hop_require_relative_wrapper_return_scope -- --nocapture
- cargo test --locked --test cli_pdg_propagation per_seed_seed_mode_pdg_keeps_two_hop_wrapper_witness_compact -- --nocapture
- cargo test --locked --test cli_pdg_propagation per_seed_diff_mode_propagation_keeps_two_hop_wrapper_witness_compact -- --nocapture
- cargo test --locked --test cli_pdg_propagation per_seed_diff_mode_ruby_two_hop_require_relative_propagation_keeps_compact_witness -- --nocapture

Task: G11-8