### PR TITLE
docs: refresh G11 PDG scope notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 ### PDG / propagation: when to use which
 - Bounded slice is the current scope model for the PDG path:
   - the goal is **not** to open the whole repo, but to recover the few nearby files that are most likely needed to explain a short multi-file bridge
-  - the current planner is a **controlled 2-hop** model: seed/changed file first, then direct boundary files, then at most one bridge-completion file per boundary side under a small per-seed budget
-  - `--with-pdg` and `--with-propagation` now share that same bounded slice planner in diff mode and seed mode
+  - the current planner is now a **bounded continuation** model: seed/changed file first, then direct boundary files, then a bounded bridge-completion file, and in the strongest Rust/Ruby cases one more `bridge_continuation_file`
+  - in practice this means G11 can now keep short `main -> wrapper -> step -> leaf` style chains in scope without turning into recursive whole-repo expansion
+  - `--with-pdg` and `--with-propagation` share that same bounded slice planner in both diff mode and seed mode
 - `--with-pdg`
   - best when you want extra Rust/Ruby local data/control-dependence context around the selected bounded slice
   - useful when plain call-graph impact is too coarse and you want to confirm which nearby file(s) should even be in scope before asking stronger flow questions
@@ -232,28 +233,36 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - `--with-propagation`
   - builds on the same bounded slice, then adds symbolic call-site / summary bridges on top
   - best when the real question is "does this value / argument / result continue across the boundary?"
+  - G11 specifically improved short Rust/Ruby wrapper-return style propagation, including two-hop wrapper / `require_relative` chains and more natural attachment for multiline call sites
   - use this when you suspect false negatives around alias chains, wrapper return-flow, imported-result continuation, or other short inter-procedural Rust/Ruby bridges
 - `--per-seed`
   - works with both normal impact and the PDG / propagation path
   - useful when you want to compare how each changed/seed symbol fans out independently, including per-seed witnesses and compact path summaries
+  - the per-seed JSON witness/slice metadata is now the easiest way to confirm whether a file was kept as a direct boundary, bridge completion, or `bridge_continuation_file`
 
 ### Current limits of the PDG / propagation path
 - Scope is intentionally bounded today:
   - the planner is still closer to a **bounded project slice** than to project-wide closure
-  - current Rust/Ruby scope selection is roughly: root file(s) + direct boundary + controlled second-hop bridge files for a few boundary sides
+  - current Rust/Ruby scope selection is roughly: root file(s) + direct boundary + bounded bridge-completion + at most one extra continuation file for the strongest short bridge family
   - that helps short 2-hop-style bridges, but it still deliberately stops before recursive whole-project expansion
   - other languages still mostly fall back to the normal call-graph signal even if you pass `--with-pdg`
 - It is **not** a project-wide PDG yet:
   - current behavior is still closer to `global call graph + bounded local DFG augmentation`
   - propagation is mostly call-site / summary-oriented, not a whole-program symbolic executor
+  - this is still **not** a true cross-file DFG; most cross-file continuity comes from bounded file selection plus symbolic bridges
 - Witnesses are better, but still intentionally minimal:
   - `impacted_witnesses.path` / `provenance_chain` / `kind_chain` expose one chosen multi-hop explanation
   - `impacted_witnesses.slice_context` now tells you which selected files on that route came from the bounded-slice planner and which seed-specific reasons retained them
+  - continuation-tier files are now labeled separately as `bridge_continuation_file`, which makes the G11 scope extension visible in `summary.slice_selection` and witness slice context
   - the `*_compact` witness fields make that explanation easier to read, but they are still summaries of one selected route
   - you still do **not** get all competing paths or a full proof that no alternative route exists
 - `-f dot` changes meaning when PDG is enabled:
   - normal `impact -f dot` shows the impact graph
   - `impact --with-pdg -f dot` shows the raw PDG/DFG-style graph instead
+- Propagation is better attached than before, but still narrow:
+  - multiline call-site attachment is more tolerant than exact `(file, line)` matching used to be, so short wrapper calls split across nearby lines are less brittle
+  - that tolerance is still intentionally local; it is not a generic expression-normalization or arbitrary argument-matching layer
+  - nested multi-input summary mapping, broader alias stitching, and richer budget-aware continuation selection are still only partially modeled
 - Ruby has improved short multi-file coverage, but still has clear boundaries:
   - short `require_relative` / alias / wrapper-return chains are better than before, including no-paren wrapper parameter flow
   - bridge scoring now tries to keep semantic alias / return-flow completions ahead of plain `require_relative` helper noise, while leaving weaker fallback paths visible as ranked-out candidates instead of silently broadening scope

--- a/README_ja.md
+++ b/README_ja.md
@@ -239,7 +239,8 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 ## PDG / propagation の使い分け
 - bounded slice は、いまの PDG path の scope モデルです
   - 目的は repo 全体を開くことではなく、短い multi-file bridge を説明するのに必要な近傍 file だけを拾うことです
-  - 現在の planner は **controlled 2-hop** で、seed/changed file → direct boundary file → boundary side ごとに必要な bridge completion file を少数だけ足す、という bounded な project slice を狙っています
+  - 現在の planner は **bounded continuation** に進んでおり、seed/changed file → direct boundary file → bounded な bridge completion file に加えて、強い Rust/Ruby case ではさらに 1 枚の `bridge_continuation_file` まで選べます
+  - 実運用で言うと、`main -> wrapper -> step -> leaf` のような短い chain を scope に入れやすくなった一方で、再帰的な whole-repo expansion にはしません
   - `--with-pdg` と `--with-propagation` は、diff モードでも seed モードでも、この同じ bounded slice planner を共有します
 - `--with-pdg`
   - 選ばれた bounded slice 上で、Rust/Ruby の local data/control dependence を少し厚く見たいとき向けです
@@ -248,28 +249,36 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - `--with-propagation`
   - 同じ bounded slice の上に call-site / summary bridge を足す拡張です
   - 引数 → callee → 代入先 のような値伝播や、wrapper return-flow / imported result continuation を見たいときに使います
+  - G11 では、短い Rust/Ruby の wrapper-return chain、2-hop の `require_relative` chain、multiline call site attach が以前より自然につながるようになりました
   - local variable flow、alias chain、wrapper return-flow、短い inter-procedural propagation の false negative を疑うときに向いています
 - `--per-seed`
   - 通常 impact だけでなく PDG / propagation path でも使えます
   - changed/seed symbol ごとの波及を個別に見たいときに便利で、seed ごとの witness や compact path も追いやすくなります
+  - file が direct boundary / bridge completion / `bridge_continuation_file` のどれとして残ったかを見るには、per-seed JSON がいちばん追いやすいです
 
 ## 現在の PDG / propagation の限界
 - scope はまだ意図的に絞っています
   - 現状は **bounded project slice** であって project-wide closure ではありません
-  - Rust/Ruby ではおおむね「root file + direct boundary + いくつかの boundary side ごとの controlled second-hop bridge file」くらいのスコープを狙っています
+  - Rust/Ruby ではおおむね「root file + direct boundary + bounded bridge completion + 強い短距離 family に対する continuation file 1 枚」くらいのスコープを狙っています
   - そのため、短い 2-hop bridge には効きますが、再帰的な whole-project expansion はしません
   - それ以外の言語では `--with-pdg` を付けても、実質的には通常の call graph シグナルに寄る場面が多いです
 - **project-wide PDG** ではありません
   - 現状は依然として `global call graph + bounded local DFG augmentation` に近い挙動です
   - propagation も whole-program symbolic execution ではなく、call-site / summary 中心の heuristic です
+  - つまり本物の cross-file DFG を作っているわけではなく、cross-file continuity の多くは bounded file selection と symbolic bridge で成立しています
 - witness は改善されたが、まだ最小表現です
   - `impacted_witnesses.path` / `provenance_chain` / `kind_chain` で 1 本の multi-hop 説明を見られるようになりました
   - `impacted_witnesses.slice_context` を見ると、その経路上に出てくる selected file が bounded-slice planner でどう選ばれたかを軽く辿れます
+  - continuation tier は `bridge_continuation_file` として別 kind で見えるようになったので、G11 の scope 拡張が JSON 上でも分かりやすくなっています
   - `*_compact` 系フィールドでその説明を読みやすく圧縮していますが、依然として 1 本の選択経路の要約です
   - 競合する複数経路の列挙や、代替経路が存在しないことの証明まではしません
 - `-f dot` の意味が切り替わります
   - 通常の `impact -f dot` は impact graph
   - `impact --with-pdg -f dot` は raw な PDG/DFG 風グラフです
+- propagation の attach は良くなったが、まだ narrow です
+  - multiline call site でも exact `(file, line)` だけに依存しないようになり、近接行に分かれた短い wrapper call は以前より拾いやすくなりました
+  - ただしこれはあくまで局所的な tolerance であって、任意の式正規化や汎用の引数対応づけではありません
+  - nested multi-input summary mapping、広い alias stitching、より賢い budget-aware continuation selection は引き続き部分的な対応に留まります
 - Ruby は short multi-file case が前進した一方で、限界もまだあります
   - `require_relative` / alias / wrapper-return の短い chain や no-paren wrapper parameter flow は以前より拾いやすくなりました
   - bridge scoring は、semantic に強い alias / return-flow completion を単純な `require_relative` helper noise より優先しつつ、弱い fallback は scope を広げず ranked-out candidate として残す方針です


### PR DESCRIPTION
## Summary
- update README and README_ja to describe the G11 bounded-continuation PDG scope instead of the older controlled-2-hop wording
- document the newly visible `bridge_continuation_file` slice metadata and the short Rust/Ruby improvements from G11
- clarify what still does *not* exist yet, including the lack of project-wide PDG / cross-file DFG and the remaining narrow propagation limitations

## Testing
- not run (docs-only change)

Task: G11-9