### PR TITLE
pdg: filter weak duplicate ruby callsite refs

### DIFF
--- a/src/dfg.rs
+++ b/src/dfg.rs
@@ -813,13 +813,22 @@ fn collect_callsite_nodes(
     collected
 }
 
+fn collect_exact_callsite_uses(
+    uses_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    file: &str,
+    line: u32,
+    expected_len: usize,
+) -> Vec<String> {
+    collect_callsite_nodes(uses_by_loc, file, line, expected_len, &[0])
+}
+
 fn collect_callsite_uses(
     uses_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
     file: &str,
     line: u32,
     expected_len: usize,
 ) -> Vec<String> {
-    let exact = collect_callsite_nodes(uses_by_loc, file, line, expected_len, &[0]);
+    let exact = collect_exact_callsite_uses(uses_by_loc, file, line, expected_len);
     if expected_len == 0 || exact.len() >= expected_len {
         return exact;
     }
@@ -832,16 +841,118 @@ fn collect_callsite_uses(
     )
 }
 
+fn collect_exact_callsite_defs(
+    defs_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    file: &str,
+    line: u32,
+) -> Vec<String> {
+    collect_callsite_nodes(defs_by_loc, file, line, 0, &[0])
+}
+
 fn collect_callsite_defs(
     defs_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
     file: &str,
     line: u32,
 ) -> Vec<String> {
-    let exact = collect_callsite_nodes(defs_by_loc, file, line, 0, &[0]);
+    let exact = collect_exact_callsite_defs(defs_by_loc, file, line);
     if !exact.is_empty() {
         return exact;
     }
     collect_callsite_nodes(defs_by_loc, file, line, 0, &[0, -1, 1, -2, 2])
+}
+
+fn filter_symbolic_propagation_refs<'a>(
+    refs: &'a [Reference],
+    defs_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    uses_by_loc: &std::collections::HashMap<(String, u32), Vec<String>>,
+    summary_by_fn: &std::collections::HashMap<String, FunctionSummary>,
+) -> Vec<&'a Reference> {
+    let mut grouped: std::collections::BTreeMap<(String, String, String), Vec<&Reference>> =
+        std::collections::BTreeMap::new();
+
+    for reference in refs.iter().filter(|r| {
+        r.kind == crate::ir::reference::RefKind::Call
+            && r.provenance == crate::ir::reference::EdgeProvenance::CallGraph
+    }) {
+        grouped
+            .entry((
+                reference.from.0.clone(),
+                reference.to.0.clone(),
+                reference.file.clone(),
+            ))
+            .or_default()
+            .push(reference);
+    }
+
+    let mut selected = Vec::new();
+    for group in grouped.into_values() {
+        let summary_input_count = group
+            .first()
+            .and_then(|reference| summary_by_fn.get(&reference.to.0))
+            .map(|summary| summary.inputs.len())
+            .unwrap_or_default()
+            .max(1);
+
+        let with_exact_defs_and_uses: Vec<&Reference> = group
+            .iter()
+            .copied()
+            .filter(|reference| {
+                let exact_defs = collect_exact_callsite_defs(
+                    defs_by_loc,
+                    reference.file.as_str(),
+                    reference.line,
+                );
+                let exact_uses = collect_exact_callsite_uses(
+                    uses_by_loc,
+                    reference.file.as_str(),
+                    reference.line,
+                    summary_input_count,
+                );
+                !exact_defs.is_empty()
+                    && !exact_uses.is_empty()
+                    && exact_uses.len() >= summary_input_count
+            })
+            .collect();
+        if !with_exact_defs_and_uses.is_empty() {
+            selected.extend(with_exact_defs_and_uses);
+            continue;
+        }
+
+        let with_exact_defs: Vec<&Reference> = group
+            .iter()
+            .copied()
+            .filter(|reference| {
+                !collect_exact_callsite_defs(defs_by_loc, reference.file.as_str(), reference.line)
+                    .is_empty()
+            })
+            .collect();
+        if !with_exact_defs.is_empty() {
+            selected.extend(with_exact_defs);
+            continue;
+        }
+
+        let with_exact_uses: Vec<&Reference> = group
+            .iter()
+            .copied()
+            .filter(|reference| {
+                let exact_uses = collect_exact_callsite_uses(
+                    uses_by_loc,
+                    reference.file.as_str(),
+                    reference.line,
+                    summary_input_count,
+                );
+                !exact_uses.is_empty() && exact_uses.len() >= summary_input_count
+            })
+            .collect();
+        if !with_exact_uses.is_empty() {
+            selected.extend(with_exact_uses);
+            continue;
+        }
+
+        selected.extend(group);
+    }
+
+    selected
 }
 
 impl PdgBuilder {
@@ -908,11 +1019,11 @@ impl PdgBuilder {
             summary_by_fn.insert(s.function_id.clone(), s);
         }
 
+        let symbolic_refs =
+            filter_symbolic_propagation_refs(refs, &defs_by_loc, &uses_by_loc, &summary_by_fn);
+
         // 1) Call-site bridges + summary-connected inter-procedural bridges
-        for r in refs.iter().filter(|r| {
-            r.kind == crate::ir::reference::RefKind::Call
-                && r.provenance == crate::ir::reference::EdgeProvenance::CallGraph
-        }) {
+        for r in symbolic_refs {
             let summary_input_count = summary_by_fn
                 .get(&r.to.0)
                 .map(|summary| summary.inputs.len())

--- a/tests/cli_pdg_propagation.rs
+++ b/tests/cli_pdg_propagation.rs
@@ -1024,6 +1024,52 @@ end
     (dir, path)
 }
 
+fn setup_ruby_require_relative_alias_caller_chain_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.email", "tester@example.com"]);
+    git(&path, &["config", "user.name", "Tester"]);
+
+    fs::create_dir_all(path.join("lib")).unwrap();
+    fs::create_dir_all(path.join("app")).unwrap();
+    fs::write(
+        path.join("lib/service.rb"),
+        r#"def bounce(value)
+  alias_value = value
+  return alias_value
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        path.join("app/runner.rb"),
+        r#"require_relative '../lib/service'
+
+def entry(seed)
+  reply = bounce(seed)
+  out = reply
+  return out
+end
+"#,
+    )
+    .unwrap();
+    git(&path, &["add", "."]);
+    git(&path, &["commit", "-m", "init", "-q"]);
+
+    fs::write(
+        path.join("lib/service.rb"),
+        r#"def bounce(value)
+  alias_value = value
+  return alias_value.to_s
+end
+"#,
+    )
+    .unwrap();
+
+    (dir, path)
+}
+
 fn setup_ruby_require_relative_no_paren_wrapper_repo() -> (TempDir, std::path::PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().to_path_buf();
@@ -3378,6 +3424,69 @@ fn ruby_require_relative_alias_return_only_gains_symbolic_edges_with_propagation
             .filter(|e| e["kind"] == "data")
             .all(|e| e["provenance"] == "symbolic_propagation")),
         "expected propagation-only data edges to stay tagged as symbolic_propagation: {prop:#}"
+    );
+}
+
+#[test]
+fn ruby_require_relative_alias_caller_chain_avoids_leaking_duplicate_callsite_refs() {
+    let (_tmp, repo) = setup_ruby_require_relative_alias_caller_chain_repo();
+    let diff = diff_text(&repo);
+
+    let prop = run_impact_json(
+        &repo,
+        &diff,
+        &[
+            "--direction",
+            "callers",
+            "--lang",
+            "ruby",
+            "--with-propagation",
+            "--format",
+            "json",
+            "--with-edges",
+        ],
+    );
+
+    let prop_data: std::collections::BTreeSet<(String, String)> = prop["edges"]
+        .as_array()
+        .expect("edges array")
+        .iter()
+        .filter(|e| e["kind"] == "data")
+        .map(|e| {
+            (
+                e["from"].as_str().unwrap().to_string(),
+                e["to"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+
+    assert!(
+        prop_data.contains(&(
+            "app/runner.rb:use:seed:4".to_string(),
+            "ruby:lib/service.rb:method:bounce:1".to_string(),
+        )),
+        "expected propagation to keep the real caller arg bridge into bounce(seed): {prop:#}"
+    );
+    assert!(
+        prop_data.contains(&(
+            "ruby:lib/service.rb:method:bounce:1".to_string(),
+            "app/runner.rb:def:reply:4".to_string(),
+        )),
+        "expected propagation to keep the immediate caller def bridge: {prop:#}"
+    );
+    assert!(
+        !prop_data.contains(&(
+            "ruby:lib/service.rb:method:bounce:1".to_string(),
+            "app/runner.rb:def:seed:3".to_string(),
+        )),
+        "unexpected duplicate-callsite leakage should not bridge callee return into the method param def: {prop:#}"
+    );
+    assert!(
+        !prop_data.contains(&(
+            "app/runner.rb:use:out:6".to_string(),
+            "ruby:lib/service.rb:method:bounce:1".to_string(),
+        )),
+        "unexpected duplicate-callsite leakage should not treat return out as another bounce callsite: {prop:#}"
     );
 }
 


### PR DESCRIPTION
## Summary
- filter duplicate symbolic-propagation call refs by preferring Ruby callsites with exact arg/def evidence
- avoid leaking later return/param-adjacent Ruby refs into alias-result propagation bridges
- add a Ruby regression covering require_relative alias chaining without bogus seed/out callsite bridges

## Testing
- cargo test --test cli_pdg_propagation