### PR TITLE
docs: update G12 continuation scope notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ CLI Overview
   - `path` expands that witness into one chosen hop-by-hop route from the root changed/seed symbol
   - `provenance_chain` / `kind_chain` make it easier to see where call / data / control / symbolic-propagation edges entered that route
   - `path_compact` / `provenance_chain_compact` / `kind_chain_compact` keep the same route in a more compressed, explanation-oriented form
+  - `bridge_execution_family` / `bridge_execution_chain_compact` add the current bounded continuation/stitching explanation on top of that path, so you can tell whether the selected route was carried by a return continuation, alias-result stitch, Ruby `require_relative` load, or a nested continuation step
   - `slice_context.selected_files_on_path` lightly connects that witness route back to the bounded-slice planner, so you can see which selected files were actually on the witness path, which hop indices they covered, and which slice-selection reasons retained them
   - `slice_context.selected_vs_pruned_reasons` adds the minimal "why this won" explanation when a selected bridge candidate beat a ranked-out competitor
   - this is still one selected shortest-path explanation, not an exhaustive proof of every possible route
@@ -224,7 +225,7 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - Bounded slice is the current scope model for the PDG path:
   - the goal is **not** to open the whole repo, but to recover the few nearby files that are most likely needed to explain a short multi-file bridge
   - the current planner is now a **bounded continuation** model: seed/changed file first, then direct boundary files, then a bounded bridge-completion file, and in the strongest Rust/Ruby cases one more `bridge_continuation_file`
-  - in practice this means G11 can now keep short `main -> wrapper -> step -> leaf` style chains in scope without turning into recursive whole-repo expansion
+  - in practice this now covers short `main -> wrapper -> step -> leaf` wrapper-return chains **and** the smallest `main -> adapter -> value -> out/shared` style alias-continuation follow-ups, without turning into recursive whole-repo expansion
   - `--with-pdg` and `--with-propagation` share that same bounded slice planner in both diff mode and seed mode
 - `--with-pdg`
   - best when you want extra Rust/Ruby local data/control-dependence context around the selected bounded slice
@@ -233,8 +234,8 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - `--with-propagation`
   - builds on the same bounded slice, then adds symbolic call-site / summary bridges on top
   - best when the real question is "does this value / argument / result continue across the boundary?"
-  - G11 specifically improved short Rust/Ruby wrapper-return style propagation, including two-hop wrapper / `require_relative` chains and more natural attachment for multiline call sites
-  - use this when you suspect false negatives around alias chains, wrapper return-flow, imported-result continuation, or other short inter-procedural Rust/Ruby bridges
+  - G11/G12 improved short Rust/Ruby continuation handling in a few concrete ways: two-hop wrapper / `require_relative` chains, selected nested multi-input continuation cases, imported-result / alias-result stitching, and less noisy Ruby duplicate-callsite attachment
+  - use this when you suspect false negatives around alias chains, wrapper return-flow, imported-result continuation, nested short multi-input bridging, or other short inter-procedural Rust/Ruby bridges
 - `--per-seed`
   - works with both normal impact and the PDG / propagation path
   - useful when you want to compare how each changed/seed symbol fans out independently, including per-seed witnesses and compact path summaries
@@ -244,7 +245,7 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - Scope is intentionally bounded today:
   - the planner is still closer to a **bounded project slice** than to project-wide closure
   - current Rust/Ruby scope selection is roughly: root file(s) + direct boundary + bounded bridge-completion + at most one extra continuation file for the strongest short bridge family
-  - that helps short 2-hop-style bridges, but it still deliberately stops before recursive whole-project expansion
+  - that now covers the best short wrapper-return chains and the narrowest alias-continuation follow-up, but it still deliberately stops before recursive whole-project expansion or family-wide closure
   - other languages still mostly fall back to the normal call-graph signal even if you pass `--with-pdg`
 - It is **not** a project-wide PDG yet:
   - current behavior is still closer to `global call graph + bounded local DFG augmentation`
@@ -253,7 +254,8 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
 - Witnesses are better, but still intentionally minimal:
   - `impacted_witnesses.path` / `provenance_chain` / `kind_chain` expose one chosen multi-hop explanation
   - `impacted_witnesses.slice_context` now tells you which selected files on that route came from the bounded-slice planner and which seed-specific reasons retained them
-  - continuation-tier files are now labeled separately as `bridge_continuation_file`, which makes the G11 scope extension visible in `summary.slice_selection` and witness slice context
+  - continuation-tier files are now labeled separately as `bridge_continuation_file`, which makes the G11/G12 scope extension visible in `summary.slice_selection` and witness slice context
+  - `bridge_execution_family` / `bridge_execution_chain_compact` give you the current compact continuation/stitching explanation for that route, but they are still representative metadata rather than a complete execution trace
   - the `*_compact` witness fields make that explanation easier to read, but they are still summaries of one selected route
   - you still do **not** get all competing paths or a full proof that no alternative route exists
 - `-f dot` changes meaning when PDG is enabled:
@@ -261,8 +263,8 @@ Based on Q54-10 re-sampling (`release-notes/0.5.4-confidence-distribution-q54-10
   - `impact --with-pdg -f dot` shows the raw PDG/DFG-style graph instead
 - Propagation is better attached than before, but still narrow:
   - multiline call-site attachment is more tolerant than exact `(file, line)` matching used to be, so short wrapper calls split across nearby lines are less brittle
-  - that tolerance is still intentionally local; it is not a generic expression-normalization or arbitrary argument-matching layer
-  - nested multi-input summary mapping, broader alias stitching, and richer budget-aware continuation selection are still only partially modeled
+  - selected nested multi-input continuation and short alias-result stitching cases are better than before, but the current model is still intentionally local and heuristic
+  - it is still **not** a generic expression-normalization or arbitrary argument-matching layer: reordered/partial bindings, wider alias zones, and richer family-aware continuation budgeting are only partially modeled
 - Ruby has improved short multi-file coverage, but still has clear boundaries:
   - short `require_relative` / alias / wrapper-return chains are better than before, including no-paren wrapper parameter flow
   - bridge scoring now tries to keep semantic alias / return-flow completions ahead of plain `require_relative` helper noise, while leaving weaker fallback paths visible as ranked-out candidates instead of silently broadening scope

--- a/README_ja.md
+++ b/README_ja.md
@@ -131,6 +131,7 @@ dimpact id --name foo -f json
   - `path` は root changed/seed symbol からそこに至る 1 本の hop-by-hop 経路を出します
   - `provenance_chain` / `kind_chain` で、その経路のどこに call / data / control / symbolic_propagation が入ったかを追いやすくなります
   - `path_compact` / `provenance_chain_compact` / `kind_chain_compact` は、その同じ経路をより説明しやすい圧縮形で返します
+  - `bridge_execution_family` / `bridge_execution_chain_compact` を見ると、その経路が return continuation / alias-result stitching / Ruby の `require_relative` load / nested continuation step のどれで支えられていたかを compact に確認できます
   - `slice_context.selected_files_on_path` を見ると、その witness 経路上の file が bounded-slice planner でどう選ばれたか、どの hop index を担当したか、どの seed-specific reason で残ったかを軽く追えます
   - `slice_context.selected_vs_pruned_reasons` には、selected された bridge candidate が ranked-out 候補に勝った最小理由が入ります
   - ただし、これは依然として 1 本の最短経路ベースの説明であり、すべての候補経路を網羅するものではありません
@@ -240,7 +241,7 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - bounded slice は、いまの PDG path の scope モデルです
   - 目的は repo 全体を開くことではなく、短い multi-file bridge を説明するのに必要な近傍 file だけを拾うことです
   - 現在の planner は **bounded continuation** に進んでおり、seed/changed file → direct boundary file → bounded な bridge completion file に加えて、強い Rust/Ruby case ではさらに 1 枚の `bridge_continuation_file` まで選べます
-  - 実運用で言うと、`main -> wrapper -> step -> leaf` のような短い chain を scope に入れやすくなった一方で、再帰的な whole-repo expansion にはしません
+  - 実運用では、`main -> wrapper -> step -> leaf` のような wrapper-return chain だけでなく、`main -> adapter -> value -> out/shared` のような最小の alias-continuation follow-up も scope に残しやすくなりましたが、再帰的な whole-repo expansion にはしません
   - `--with-pdg` と `--with-propagation` は、diff モードでも seed モードでも、この同じ bounded slice planner を共有します
 - `--with-pdg`
   - 選ばれた bounded slice 上で、Rust/Ruby の local data/control dependence を少し厚く見たいとき向けです
@@ -249,8 +250,8 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - `--with-propagation`
   - 同じ bounded slice の上に call-site / summary bridge を足す拡張です
   - 引数 → callee → 代入先 のような値伝播や、wrapper return-flow / imported result continuation を見たいときに使います
-  - G11 では、短い Rust/Ruby の wrapper-return chain、2-hop の `require_relative` chain、multiline call site attach が以前より自然につながるようになりました
-  - local variable flow、alias chain、wrapper return-flow、短い inter-procedural propagation の false negative を疑うときに向いています
+  - G11/G12 では、短い Rust/Ruby の wrapper-return chain、2-hop の `require_relative` chain、selected な nested multi-input continuation、imported-result / alias-result stitching、Ruby の duplicate-callsite attach のノイズ低減が前進しました
+  - local variable flow、alias chain、wrapper return-flow、nested な短距離 multi-input bridge、短い inter-procedural propagation の false negative を疑うときに向いています
 - `--per-seed`
   - 通常 impact だけでなく PDG / propagation path でも使えます
   - changed/seed symbol ごとの波及を個別に見たいときに便利で、seed ごとの witness や compact path も追いやすくなります
@@ -260,7 +261,7 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - scope はまだ意図的に絞っています
   - 現状は **bounded project slice** であって project-wide closure ではありません
   - Rust/Ruby ではおおむね「root file + direct boundary + bounded bridge completion + 強い短距離 family に対する continuation file 1 枚」くらいのスコープを狙っています
-  - そのため、短い 2-hop bridge には効きますが、再帰的な whole-project expansion はしません
+  - いまは短い wrapper-return chain と最小の alias-continuation follow-up までは扱えますが、family 全体を再帰的に閉じるような whole-project expansion はしません
   - それ以外の言語では `--with-pdg` を付けても、実質的には通常の call graph シグナルに寄る場面が多いです
 - **project-wide PDG** ではありません
   - 現状は依然として `global call graph + bounded local DFG augmentation` に近い挙動です
@@ -269,7 +270,8 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
 - witness は改善されたが、まだ最小表現です
   - `impacted_witnesses.path` / `provenance_chain` / `kind_chain` で 1 本の multi-hop 説明を見られるようになりました
   - `impacted_witnesses.slice_context` を見ると、その経路上に出てくる selected file が bounded-slice planner でどう選ばれたかを軽く辿れます
-  - continuation tier は `bridge_continuation_file` として別 kind で見えるようになったので、G11 の scope 拡張が JSON 上でも分かりやすくなっています
+  - continuation tier は `bridge_continuation_file` として別 kind で見えるようになったので、G11/G12 の scope 拡張が JSON 上でも分かりやすくなっています
+  - `bridge_execution_family` / `bridge_execution_chain_compact` で、その経路の continuation / stitching explanation を compact に見られますが、これは依然として代表経路ベースの metadata です
   - `*_compact` 系フィールドでその説明を読みやすく圧縮していますが、依然として 1 本の選択経路の要約です
   - 競合する複数経路の列挙や、代替経路が存在しないことの証明まではしません
 - `-f dot` の意味が切り替わります
@@ -277,8 +279,8 @@ Q54-10 の再計測結果（`release-notes/0.5.4-confidence-distribution-q54-10.
   - `impact --with-pdg -f dot` は raw な PDG/DFG 風グラフです
 - propagation の attach は良くなったが、まだ narrow です
   - multiline call site でも exact `(file, line)` だけに依存しないようになり、近接行に分かれた短い wrapper call は以前より拾いやすくなりました
-  - ただしこれはあくまで局所的な tolerance であって、任意の式正規化や汎用の引数対応づけではありません
-  - nested multi-input summary mapping、広い alias stitching、より賢い budget-aware continuation selection は引き続き部分的な対応に留まります
+  - selected な nested multi-input continuation や短い alias-result stitching は改善しましたが、モデル自体は依然として局所的で heuristic です
+  - 任意の式正規化や汎用の引数対応づけがあるわけではなく、reordered/partial binding、広い alias zone、より賢い family-aware continuation budget は引き続き部分的な対応に留まります
 - Ruby は short multi-file case が前進した一方で、限界もまだあります
   - `require_relative` / alias / wrapper-return の短い chain や no-paren wrapper parameter flow は以前より拾いやすくなりました
   - bridge scoring は、semantic に強い alias / return-flow completion を単純な `require_relative` helper noise より優先しつつ、弱い fallback は scope を広げず ranked-out candidate として残す方針です


### PR DESCRIPTION
## Summary
- update README and README_ja for the G12 continuation-scope expansion
- document the new compact bridge-execution witness metadata and the short alias-continuation follow-up now covered by the bounded planner
- clarify what still remains intentionally out of scope, including recursive closure, generic argument binding, and broader family-aware continuation budgeting

## Testing
- not run (docs only)