### PR TITLE
ci: repair release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  push:
-    name: Build and Push docker image for CI
-    runs-on: ubuntu-latest 
+  publish_image:
+    name: Publish release image
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -21,27 +21,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Log in to the Container registry
-        uses: docker/login-action@3
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=manual-smoke,enable=${{ github.event_name == 'workflow_dispatch' }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@6
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           file: docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Release GitHub Actions
-        uses: technote-space/release-github-actions@v8
+
+  create_github_release:
+    name: Create GitHub release
+    needs: publish_image
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "GitHub release $TAG_NAME already exists; skipping create."
+          else
+            gh release create "$TAG_NAME" --title "$TAG_NAME" --generate-notes
+          fi


### PR DESCRIPTION
## Summary
- fix the broken Docker action refs in `.github/workflows/release.yml`
- replace the GitHub-Actions-specific release step with a normal GitHub Release creation step for tag pushes
- make `workflow_dispatch` a safe manual smoke path that builds the release image without pushing packages or creating a release

## Testing
- python3 - <<'PY'
import yaml
with open('.github/workflows/release.yml') as f:
    yaml.safe_load(f)
print('yaml-ok')
PY
- gh workflow view release.yml
- planned manual `workflow_dispatch` smoke run on this branch after push