### PR TITLE
Add nightly strict LSP failure inventory memo

### DIFF
--- a/release-notes/0.5.3-nightly-strict-lsp-failure-inventory-f14-1.md
+++ b/release-notes/0.5.3-nightly-strict-lsp-failure-inventory-f14-1.md
@@ -1,0 +1,153 @@
+# F14-1 Nightly strict real-LSP failure inventory (Ruby install vs finalizer)
+
+- Run ID: `b1c001f0-c7b6-473e-b70c-83904407cd6a`
+- Sample window: latest 8 scheduled nightly runs on `main`
+- Workflow: `.github/workflows/nightly-strict-lsp.yml`
+- Sampled runs all point at head SHA `9c1de0445f17652714397b96aa6c2064ff3eb52b`
+
+## 1) Sampled runs
+| Run | Created (UTC) | Job conclusion | Failed job step shown by Actions UI |
+| --- | --- | --- | --- |
+| [24097546104](https://github.com/n01e0/dimpact/actions/runs/24097546104) | 2026-04-07 18:24 | failure | `Finalize nightly result with retry policy` |
+| [24044610166](https://github.com/n01e0/dimpact/actions/runs/24044610166) | 2026-04-06 18:23 | failure | `Finalize nightly result with retry policy` |
+| [24007486959](https://github.com/n01e0/dimpact/actions/runs/24007486959) | 2026-04-05 18:14 | failure | `Finalize nightly result with retry policy` |
+| [23984680535](https://github.com/n01e0/dimpact/actions/runs/23984680535) | 2026-04-04 18:13 | failure | `Finalize nightly result with retry policy` |
+| [23956965237](https://github.com/n01e0/dimpact/actions/runs/23956965237) | 2026-04-03 18:16 | failure | `Finalize nightly result with retry policy` |
+| [23915470698](https://github.com/n01e0/dimpact/actions/runs/23915470698) | 2026-04-02 18:22 | failure | `Finalize nightly result with retry policy` |
+| [23864143118](https://github.com/n01e0/dimpact/actions/runs/23864143118) | 2026-04-01 18:23 | failure | `Finalize nightly result with retry policy` |
+| [23813040414](https://github.com/n01e0/dimpact/actions/runs/23813040414) | 2026-03-31 18:24 | failure | `Finalize nightly result with retry policy` |
+
+## 2) Repeated classification signature
+Every sampled run produced the same classifier totals from `nightly-flaky-classification.json`:
+
+| category | count |
+| --- | ---: |
+| install | 3 |
+| startup | 12 |
+| capability | 0 |
+| timeout | 12 |
+
+What those numbers actually mean in the latest run (`24097546104`):
+
+- `install=3`
+  - `install-ruby.log:21`: actual Ruby install error
+  - `engine-lsp-strict-preflight.log:6`: Ruby lane unset because install failed
+  - `engine-lsp-strict-preflight.log:7`: Python lane unset despite install step reporting success (classifier noise, not the primary issue in this memo)
+- `startup=12` and `timeout=12`
+  - duplicated java initialize-timeout evidence from `engine-lsp-strict-e2e.log` and `run-engine-lsp-strict.log`
+
+## 3) Bucket A, Ruby install failure
+### Primary evidence
+From `nightly-strict-lsp-execution-logs/install-ruby.log` in run `24097546104`:
+
+```text
+[ruby] ruby=ruby 3.4.4 ... [x86_64-linux-musl] gem=3.6.7
+Building native extensions. This could take a while...
+ERROR:  Error installing ruby-lsp:
+  ERROR: Failed to build gem native extension.
+...
+creating Makefile
+...
+make failedNo such file or directory - make
+::error::[ruby] gem install failed (ruby-lsp)
+```
+
+Preflight then disables the Ruby strict lane:
+
+```text
+DIMPACT_E2E_STRICT_LSP_RUBY=unset reason=ruby-lsp unavailable or install failed (install=failure)
+```
+
+Retry repeats the same failure in `retry-setup.log`:
+
+```text
+gem install ruby-lsp --no-document
+...
+make failedNo such file or directory - make
+```
+
+### Classification
+- Primary bucket: `install`
+- Scope: Ruby-only root cause
+- Immediate consequence: Ruby strict lane is not exercised, because preflight leaves `DIMPACT_E2E_STRICT_LSP_RUBY` unset.
+
+### Repro conditions
+The sampled failures are reproducible under the current nightly environment when all of these are true:
+
+1. Workflow runs inside `ghcr.io/n01e0/dimpact-ci:latest` on the current musl-based image path.
+2. Base tools step installs Ruby runtime/dev packages, but no `make`/build toolchain.
+3. Nightly Ruby setup executes:
+   ```bash
+   gem install ruby-lsp --no-document
+   ```
+4. `ruby-lsp` pulls `prism`, which builds a native extension and immediately dies with `make failedNo such file or directory - make`.
+
+### Cut line
+This is an install/environment defect, not a finalizer defect.
+
+## 4) Bucket B, finalizer failure
+### Primary evidence
+All sampled runs end with the workflow step `Finalize nightly result with retry policy` failing.
+
+Latest run (`24097546104`) logged:
+
+```text
+[finalize] strict initial=failure strict retry=failure grad initial=success grad retry=success retry enabled=1 strict_ok=0 grad_ok=1
+nightly failed after applying retry policy
+```
+
+That matches the finalizer code in `.github/workflows/nightly-strict-lsp.yml`:
+
+- `strict_ok=1` only if either initial or retry strict suite succeeds
+- `grad_ok=1` only if either graduation check succeeds
+- the step exits 1 when strict stays red, even if graduation is green
+
+### What actually feeds the finalizer red state in the sampled runs
+The finalizer is red because the strict suite is still genuinely failing after retry:
+
+- Java: `lsp initialize timeout or invalid response` on `java/callers`, `java/callees`, `java/both`
+- TypeScript/JavaScript: `lsp changed_symbols returned no symbols; policy=strict language=Auto`
+- Retry does not clear either class of strict failure
+- Graduation stays green in both initial and retry paths
+
+So the sampled `finalizer` failures are downstream aggregation of unresolved strict failures, not standalone proof of a false-negative finalizer bug.
+
+### Repro conditions
+Two ways to reproduce the finalizer symptom:
+
+1. Real workflow repro
+   - Run `nightly-strict-lsp.yml` on `main` (schedule or `workflow_dispatch`)
+   - Let initial strict E2E fail
+   - Let retry strict E2E fail again
+   - Keep graduation check green
+   - Finalizer exits 1 by design
+
+2. Minimal shell repro of the aggregator logic
+   ```bash
+   init_strict=failure
+   retry_strict=failure
+   init_grad=success
+   retry_grad=success
+   if [[ "$init_strict" != success && "$retry_strict" != success ]] || \
+      [[ "$init_grad" != success && "$retry_grad" != success ]]; then
+     echo "nightly failed after applying retry policy"
+     exit 1
+   fi
+   ```
+
+### Cut line
+This is a workflow/result-aggregation symptom. In the sampled runs it is not the primary root cause, because upstream strict failures remain red after retry.
+
+## 5) Ruby install vs finalizer, the split memo
+- Ruby install failure is a concrete env/setup defect and belongs to the `install` track (`F14-2` scope).
+- Finalizer failure is the only red step visible in Actions UI because the setup/test steps run with `continue-on-error`, but the finalizer still sees their `outcome` values.
+- In the current sample set, finalizer is behaving consistently with the underlying outcomes. I do **not** see evidence here of a retry-recovered run being turned red only by bad finalization.
+- Said differently: the latest failures are a mix of
+  - Ruby install/env failure,
+  - Java startup/timeout failure,
+  - TypeScript/JavaScript strict logic failure,
+  and the finalizer is merely the place where that unresolved state is surfaced.
+
+## 6) Follow-up mapping
+- `F14-2`: harden Ruby install / health-check / retry so `ruby-lsp` can actually come up in nightly.
+- `F14-3`: only needs a finalizer fix if we can produce a run where retry turns strict green but the finalizer still exits 1. That pattern was not present in the latest 8 scheduled runs.


### PR DESCRIPTION
## Summary
- add F14-1 memo for the latest 8 nightly strict real-LSP failures
- separate Ruby install failure evidence from finalizer-step failure evidence
- record concrete repro conditions and follow-up mapping for F14-2/F14-3

## Testing
- not run (docs-only change)