### PR TITLE
Harden nightly Ruby LSP retry handling

### DIFF
--- a/.github/workflows/nightly-strict-lsp.yml
+++ b/.github/workflows/nightly-strict-lsp.yml
@@ -32,11 +32,11 @@ jobs:
           if command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-              git bash python3 nodejs npm ripgrep ca-certificates curl openjdk-17-jre-headless ruby-full
+              git bash python3 nodejs npm ripgrep ca-certificates curl openjdk-17-jre-headless ruby-full build-essential
           elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache git bash python3 nodejs npm ripgrep ca-certificates curl openjdk17-jre ruby ruby-dev
+            apk add --no-cache git bash python3 nodejs npm ripgrep ca-certificates curl openjdk17-jre ruby ruby-dev build-base
           elif command -v yum >/dev/null 2>&1; then
-            yum install -y git bash python3 nodejs npm ripgrep ca-certificates curl java-17-openjdk-headless ruby ruby-devel
+            yum install -y git bash python3 nodejs npm ripgrep ca-certificates curl java-17-openjdk-headless ruby ruby-devel gcc gcc-c++ make
           else
             echo "no supported package manager found to install required base tools" >&2
             exit 1
@@ -238,24 +238,59 @@ jobs:
           LOG="$NIGHTLY_LOG_DIR/install-ruby.log"
           exec > >(tee -a "$LOG") 2>&1
           echo "[ruby] ruby=$(ruby -v) gem=$(gem --version)"
+          if command -v make >/dev/null 2>&1; then
+            echo "[ruby] make=$(make --version | head -n 1)"
+          else
+            echo "[ruby] make=missing"
+          fi
+          if command -v gcc >/dev/null 2>&1; then
+            echo "[ruby] gcc=$(gcc --version | head -n 1)"
+          else
+            echo "[ruby] gcc=missing"
+          fi
 
-          if ! gem install ruby-lsp --no-document; then
-            echo "::error::[ruby] gem install failed (ruby-lsp)"
+          install_ruby_lsp() {
+            gem install ruby-lsp --no-document
+          }
+
+          ruby_lsp_healthcheck() {
+            if ! command -v ruby-lsp >/dev/null 2>&1; then
+              echo "::error::[ruby] ruby-lsp not found in PATH after install"
+              return 1
+            fi
+
+            echo "[ruby] ruby-lsp path=$(command -v ruby-lsp)"
+            if ! ruby-lsp --version >/tmp/ruby-lsp-version.log 2>&1; then
+              echo "::error::[ruby] ruby-lsp --version failed"
+              cat /tmp/ruby-lsp-version.log >&2
+              return 1
+            fi
+
+            if ! ruby-lsp --help >/tmp/ruby-lsp-help.log 2>&1; then
+              echo "::error::[ruby] ruby-lsp --help failed"
+              cat /tmp/ruby-lsp-help.log >&2
+              return 1
+            fi
+
+            echo "[ruby] ruby-lsp version=$(head -n 1 /tmp/ruby-lsp-version.log)"
+            echo "[ruby] health-check=ok"
+          }
+
+          if ! install_ruby_lsp; then
+            echo "[ruby] first gem install failed, retrying once"
+            if ! install_ruby_lsp; then
+              echo "phase=install" >> "$GITHUB_OUTPUT"
+              echo "::error::[ruby] gem install failed (ruby-lsp) after retry"
+              exit 1
+            fi
+          fi
+
+          if ! ruby_lsp_healthcheck; then
+            echo "phase=healthcheck" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
-          if ! command -v ruby-lsp >/dev/null 2>&1; then
-            echo "::error::[ruby] ruby-lsp not found in PATH after install"
-            exit 1
-          fi
-
-          echo "[ruby] ruby-lsp path=$(command -v ruby-lsp)"
-          if ! ruby-lsp --help >/tmp/ruby-lsp-help.log 2>&1; then
-            echo "::error::[ruby] ruby-lsp --help failed"
-            cat /tmp/ruby-lsp-help.log >&2
-            exit 1
-          fi
-          echo "[ruby] health-check=ok"
+          echo "phase=success" >> "$GITHUB_OUTPUT"
 
       - name: Preflight strict real-LSP targets (skip-safe)
         id: preflight
@@ -272,6 +307,7 @@ jobs:
           go_install='${{ steps.install_go.outcome }}'
           java_install='${{ steps.install_java.outcome }}'
           ruby_install='${{ steps.install_ruby.outcome }}'
+          ruby_phase='${{ steps.install_ruby.outputs.phase }}'
 
           active_lanes=",${STRICT_LSP_ACTIVE_LANES:-go,typescript,javascript,java,ruby,python},"
           lane_allowed() {
@@ -376,11 +412,15 @@ jobs:
 
           if lane_allowed "ruby"; then
             if [ "$ruby_install" = "success" ] && has_cmd_help ruby-lsp; then
-              ruby_reason="ruby-lsp available (install=${ruby_install})"
+              ruby_reason="ruby-lsp available (install=${ruby_install} phase=${ruby_phase:-success})"
               set_gate_enabled "DIMPACT_E2E_STRICT_LSP_RUBY" "$ruby_reason"
               ruby_enabled=1
             else
-              ruby_reason="ruby-lsp unavailable or install failed (install=${ruby_install})"
+              if [ "${ruby_phase:-unknown}" = "healthcheck" ]; then
+                ruby_reason="ruby-lsp install completed but health-check failed (install=${ruby_install} phase=${ruby_phase:-unknown})"
+              else
+                ruby_reason="ruby-lsp unavailable or install failed (install=${ruby_install} phase=${ruby_phase:-unknown})"
+              fi
               set_gate_unset "DIMPACT_E2E_STRICT_LSP_RUBY" "$ruby_reason"
             fi
           else
@@ -640,6 +680,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Retry setup actions for install/startup flaky types
+        id: retry_setup
         if: always() && steps.retry_policy.outputs.enabled == '1' && (steps.retry_policy.outputs.install == '1' || steps.retry_policy.outputs.startup == '1')
         run: |
           set -euo pipefail
@@ -662,7 +703,32 @@ jobs:
             ln -sf "$JDTLS_BIN" "$HOME/.local/bin/jdtls"
           fi
 
-          gem install ruby-lsp --no-document || true
+          ruby_lsp_healthcheck() {
+            command -v ruby-lsp >/dev/null 2>&1 || return 1
+            ruby-lsp --version >/tmp/ruby-lsp-retry-version.log 2>&1 || return 1
+            ruby-lsp --help >/tmp/ruby-lsp-retry-help.log 2>&1 || return 1
+          }
+
+          ruby_retry_result="not-needed"
+          if ruby_lsp_healthcheck; then
+            echo "[retry][ruby] existing ruby-lsp passed health-check"
+          else
+            echo "[retry][ruby] retrying gem install + health-check"
+            if gem install ruby-lsp --no-document && ruby_lsp_healthcheck; then
+              if [ '${{ steps.install_ruby.outcome }}' != 'success' ]; then
+                ruby_retry_result="recovered"
+              else
+                ruby_retry_result="healthcheck-recovered"
+              fi
+              echo "[retry][ruby] ruby-lsp health-check recovered"
+            else
+              ruby_retry_result="persistent-failure"
+              echo "[retry][ruby] ruby-lsp retry did not recover"
+            fi
+          fi
+
+          echo "ruby_install_result=$ruby_retry_result" >> "$GITHUB_OUTPUT"
+          echo "retry-status: language=ruby category=install result=$ruby_retry_result"
 
           echo "[retry] setup retry completed (best effort)"
 
@@ -736,6 +802,32 @@ jobs:
           status=${PIPESTATUS[0]}
           set -e
           exit $status
+
+      - name: Reclassify nightly flaky causes after retry absorption
+        if: always()
+        run: |
+          set -euo pipefail
+          LOG="$NIGHTLY_LOG_DIR/run-flaky-classifier-final.log"
+          exec > >(tee -a "$LOG") 2>&1
+
+          if [ -f "$NIGHTLY_LOG_DIR/nightly-flaky-classification.json" ]; then
+            cp "$NIGHTLY_LOG_DIR/nightly-flaky-classification.json" "$NIGHTLY_LOG_DIR/nightly-flaky-classification-initial.json"
+          fi
+          if [ -f "$NIGHTLY_LOG_DIR/nightly-flaky-classification.md" ]; then
+            cp "$NIGHTLY_LOG_DIR/nightly-flaky-classification.md" "$NIGHTLY_LOG_DIR/nightly-flaky-classification-initial.md"
+          fi
+
+          scripts/classify-nightly-flaky.sh \
+            "$NIGHTLY_LOG_DIR" \
+            "$NIGHTLY_LOG_DIR/nightly-flaky-classification.json" \
+            "$NIGHTLY_LOG_DIR/nightly-flaky-classification.md"
+
+          {
+            echo
+            echo "## final flaky classification after retry absorption"
+            echo
+            cat "$NIGHTLY_LOG_DIR/nightly-flaky-classification.md"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Finalize nightly result with retry policy
         if: always()

--- a/docs/nightly-strict-lsp-flaky-points.md
+++ b/docs/nightly-strict-lsp-flaky-points.md
@@ -122,15 +122,20 @@ cargo test -q --test engine_lsp
 ### 6.1 triage（自動分類）
 
 1. `scripts/classify-nightly-flaky.sh` が `nightly-logs/*.log` を走査
-2. flaky を 4分類で集計
+2. flaky を分類し、retry 実行後は retry 吸収済みの install を再分類する
    - `install`
+   - `retry_absorbed`
    - `startup`
+   - `logic`
    - `capability`
    - `timeout`
 3. 生成物
    - `nightly-flaky-classification.json`
    - `nightly-flaky-classification.md`
-4. CI summary には分類結果が自動追記される
+4. retry 前の分類は retry policy 判定に使い、retry 後に最終分類を上書きする
+   - `nightly-flaky-classification-initial.json/.md`: retry policy 用スナップショット
+   - `nightly-flaky-classification.json/.md`: retry 吸収後の最終分類
+5. CI summary には初回分類結果が自動追記され、failure triage は最終分類を使う
 
 ### 6.2 retry（タイプ別ポリシー）
 
@@ -139,10 +144,12 @@ cargo test -q --test engine_lsp
 - `install` > 0: **retry 1回**（setup系を best-effort 再実行）
 - `startup` > 0: **retry 1回**
 - `timeout` > 0: **retry 1回**
-- `capability` のみ: **retry しない**（非一時要因扱い）
+- `logic` / `capability` のみ: **retry しない**（非一時要因扱い）
 
 再試行時は `engine_lsp` strict E2E / graduation check を policy-gated で再実行し、
-初回 + retry を統合して最終成功判定する。
+初回 + retry を統合して最終成功判定する。retry 後は Ruby install のような
+setup 失敗が回復したケースを `retry_absorbed` へ移し、残った strict failure を
+`logic` / `startup` / `timeout` として見直す。
 
 ### 6.3 failure summary（原因/言語/再現）
 

--- a/release-notes/0.5.3-ruby-nightly-hardening-f14-2.md
+++ b/release-notes/0.5.3-ruby-nightly-hardening-f14-2.md
@@ -1,0 +1,28 @@
+# F14-2 Ruby nightly strict real-LSP hardening
+
+## What changed
+- nightly base-tools install now brings a native-extension build toolchain for apt/apk/yum runners so `gem install ruby-lsp` is not missing `make`/compiler prerequisites
+- Ruby nightly install step now:
+  - logs `make` / `gcc` availability
+  - retries `gem install ruby-lsp --no-document` once
+  - runs explicit `ruby-lsp --version` + `ruby-lsp --help` health-checks
+  - exports `phase=success|install|healthcheck` so preflight can describe the failure mode correctly
+- retry setup now performs Ruby-specific health-check recovery and emits a structured retry marker:
+  - `retry-status: language=ruby category=install result=...`
+- nightly flaky classification now:
+  - detects `logic` failures from strict E2E output
+  - understands retry recovery markers and moves recovered install failures to `retry_absorbed`
+  - avoids counting preflight `install=success` lines as install failures
+  - infers language from lane/gate log lines more accurately
+- failure summary docs now describe the retry-absorbed vs logic split
+
+## Why
+Recent nightly failures showed two different signals being conflated:
+1. Ruby `ruby-lsp` setup failing because the runner image lacked native build tools
+2. downstream strict E2E logic failures that remained after retry
+
+This change makes Ruby setup sturdier and keeps final failure triage from reporting a recovered install flake as the primary remaining cause.
+
+## Expected behavior after this change
+- if Ruby install fails once but retry recovers, final classification should show `retry_absorbed` for Ruby and keep remaining strict failures under `logic` / `startup` / `timeout`
+- if Ruby install cannot recover, it remains an `install` failure with clearer `phase=install|healthcheck` evidence

--- a/scripts/classify-nightly-flaky.sh
+++ b/scripts/classify-nightly-flaky.sh
@@ -32,6 +32,16 @@ LANG_HINTS = {
     "rust": "rust",
 }
 
+GATE_LANG_HINTS = {
+    "TYPESCRIPT": "typescript",
+    "JAVASCRIPT": "javascript",
+    "PYTHON": "python",
+    "GO": "go",
+    "JAVA": "java",
+    "RUBY": "ruby",
+    "RUST": "rust",
+}
+
 FILE_LANG_HINTS = [
     ("install-ts-js", "typescript/javascript"),
     ("install-python", "python"),
@@ -70,7 +80,13 @@ TIMEOUT_PATTERNS = [
     re.compile(r"exit_code=124", re.I),
 ]
 
-CATEGORY_ORDER = ["install", "startup", "capability", "timeout"]
+LOGIC_PATTERNS = [
+    re.compile(r"cause=logic", re.I),
+    re.compile(r"logic error=", re.I),
+    re.compile(r"changed_symbols returned no symbols", re.I),
+]
+
+CATEGORY_ORDER = ["install", "retry_absorbed", "startup", "logic", "capability", "timeout"]
 
 
 def detect_lang_from_file(path: Path) -> str:
@@ -82,6 +98,14 @@ def detect_lang_from_file(path: Path) -> str:
 
 
 def detect_lang_from_line(line: str) -> str | None:
+    lane_m = re.search(r"lane=([a-z_]+)/", line, re.I)
+    if lane_m:
+        return LANG_HINTS.get(lane_m.group(1).strip().lower(), lane_m.group(1).strip().lower())
+
+    gate_m = re.search(r"DIMPACT_E2E_STRICT_LSP_([A-Z_]+)", line)
+    if gate_m:
+        return GATE_LANG_HINTS.get(gate_m.group(1).strip().upper())
+
     m = re.search(r"\[([^\]]+)\]", line)
     if not m:
         return None
@@ -91,8 +115,10 @@ def detect_lang_from_line(line: str) -> str | None:
 
 def category_hits(line: str):
     hits = []
+    is_preflight_success_echo = "DIMPACT_E2E_STRICT_LSP_" in line and "install=success" in line
+
     for p in INSTALL_PATTERNS:
-        if p.search(line):
+        if p.search(line) and not is_preflight_success_echo:
             hits.append("install")
             break
     for p in STARTUP_PATTERNS:
@@ -107,6 +133,10 @@ def category_hits(line: str):
         if p.search(line):
             hits.append("timeout")
             break
+    for p in LOGIC_PATTERNS:
+        if p.search(line):
+            hits.append("logic")
+            break
     # classify initialize-timeout primarily as startup + timeout
     if "initialize timeout or invalid response" in line.lower():
         if "startup" not in hits:
@@ -115,10 +145,39 @@ def category_hits(line: str):
             hits.append("timeout")
     return hits
 
+
+retry_absorbed = set()
+
+
+def canonical_lang(lang: str) -> str:
+    value = (lang or "unknown").strip().lower()
+    return LANG_HINTS.get(value, value)
+
 entries_by_cat = defaultdict(list)
 seen = set()
+log_files = sorted(log_dir.glob("*.log"))
 
-for path in sorted(log_dir.glob("*.log")):
+for path in log_files:
+    file_lang = detect_lang_from_file(path)
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        continue
+
+    for i, line in enumerate(lines, start=1):
+        retry_m = re.search(
+            r"retry-status:\s*language=([a-z_/.-]+)\s+category=([a-z_]+)\s+result=([a-z_-]+)",
+            line,
+            re.I,
+        )
+        if retry_m:
+            lang = canonical_lang(retry_m.group(1))
+            category = retry_m.group(2).strip().lower()
+            result = retry_m.group(3).strip().lower()
+            if category == "install" and result in {"recovered", "healthcheck-recovered"}:
+                retry_absorbed.add((lang, category))
+
+for path in log_files:
     file_lang = detect_lang_from_file(path)
     try:
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -131,10 +190,13 @@ for path in sorted(log_dir.glob("*.log")):
             continue
         line_lang = detect_lang_from_line(line)
         lang = line_lang or file_lang
+        lang = canonical_lang(lang)
         snippet = line.strip()
         if len(snippet) > 220:
             snippet = snippet[:217] + "..."
         for cat in cats:
+            if cat == "install" and (lang, "install") in retry_absorbed:
+                cat = "retry_absorbed"
             key = (cat, path.name, i, snippet)
             if key in seen:
                 continue

--- a/scripts/summarize-nightly-failure.sh
+++ b/scripts/summarize-nightly-failure.sh
@@ -14,7 +14,7 @@ log_dir = Path(sys.argv[1])
 class_json = Path(sys.argv[2])
 out_md = Path(sys.argv[3])
 
-CATEGORY_ORDER = ["install", "startup", "capability", "timeout"]
+CATEGORY_ORDER = ["install", "retry_absorbed", "startup", "logic", "capability", "timeout"]
 
 
 def lang_norm(lang: str) -> str:
@@ -57,6 +57,13 @@ def repro_for(cat: str, lang: str) -> str:
     if cat == "startup":
         gate = gate_for_lang(lang)
         return f"{gate} cargo test -q --test engine_lsp"
+    if cat == "retry_absorbed":
+        if l == "ruby":
+            return "gem install ruby-lsp --no-document && ruby-lsp --version && ruby-lsp --help"
+        return "rerun workflow_dispatch and confirm retry-setup.log reports result=recovered"
+    if cat == "logic":
+        gate = gate_for_lang(lang)
+        return f"env {gate} cargo test -q --test engine_lsp"
     if cat == "capability":
         gate = gate_for_lang(lang)
         return f"grep -n \"{gate.split('=')[0]}\" nightly-logs/engine-lsp-strict-preflight.log"


### PR DESCRIPTION
## Summary
- harden nightly Ruby LSP setup with build tools, retry, and explicit health checks
- reclassify recovered install flakes as retry_absorbed and surface remaining logic failures separately
- update nightly failure docs and add an F14-2 release note

## Testing
- bash -n scripts/classify-nightly-flaky.sh
- bash -n scripts/summarize-nightly-failure.sh
- python3 with PyYAML to parse .github/workflows/nightly-strict-lsp.yml
- synthetic log-dir check for retry_absorbed vs logic classification