### PR TITLE
Harden nightly retry finalizer aggregation

### DIFF
--- a/.github/workflows/nightly-strict-lsp.yml
+++ b/.github/workflows/nightly-strict-lsp.yml
@@ -537,6 +537,11 @@ jobs:
           cargo test -q --locked --test engine_lsp 2>&1 | tee "$STRICT_E2E_LOG"
           status=${PIPESTATUS[0]}
           set -e
+          if [ "$status" -eq 0 ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
           echo "::endgroup::"
           exit $status
 
@@ -570,6 +575,11 @@ jobs:
           scripts/verify-lsp-graduation.sh --skip-regression 2>&1 | tee "$GRAD_LOG"
           status=${PIPESTATUS[0]}
           set -e
+          if [ "$status" -eq 0 ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
           exit $status
 
       - name: Publish LSP graduation check summary
@@ -784,6 +794,11 @@ jobs:
           cargo test -q --locked --test engine_lsp 2>&1 | tee "$STRICT_E2E_RETRY_LOG"
           status=${PIPESTATUS[0]}
           set -e
+          if [ "$status" -eq 0 ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
           echo "::endgroup::"
           exit $status
 
@@ -801,6 +816,11 @@ jobs:
           scripts/verify-lsp-graduation.sh --skip-regression 2>&1 | tee "$GRAD_RETRY_LOG"
           status=${PIPESTATUS[0]}
           set -e
+          if [ "$status" -eq 0 ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
           exit $status
 
       - name: Reclassify nightly flaky causes after retry absorption
@@ -831,43 +851,19 @@ jobs:
 
       - name: Finalize nightly result with retry policy
         if: always()
+        env:
+          INIT_STRICT_RESULT: ${{ steps.strict_e2e_initial.outputs.result }}
+          INIT_STRICT_OUTCOME: ${{ steps.strict_e2e_initial.outcome }}
+          INIT_GRAD_RESULT: ${{ steps.grad_check_initial.outputs.result }}
+          INIT_GRAD_OUTCOME: ${{ steps.grad_check_initial.outcome }}
+          RETRY_ENABLED: ${{ steps.retry_policy.outputs.enabled }}
+          RETRY_STRICT_RESULT: ${{ steps.strict_e2e_retry.outputs.result }}
+          RETRY_STRICT_OUTCOME: ${{ steps.strict_e2e_retry.outcome }}
+          RETRY_GRAD_RESULT: ${{ steps.grad_check_retry.outputs.result }}
+          RETRY_GRAD_OUTCOME: ${{ steps.grad_check_retry.outcome }}
         run: |
           set -euo pipefail
-
-          init_strict='${{ steps.strict_e2e_initial.outcome }}'
-          init_grad='${{ steps.grad_check_initial.outcome }}'
-          retry_enabled='${{ steps.retry_policy.outputs.enabled }}'
-          retry_strict='${{ steps.strict_e2e_retry.outcome }}'
-          retry_grad='${{ steps.grad_check_retry.outcome }}'
-
-          strict_ok=0
-          grad_ok=0
-
-          if [ "$init_strict" = "success" ] || [ "$retry_strict" = "success" ]; then
-            strict_ok=1
-          fi
-
-          if [ "$init_grad" = "success" ] || [ "$retry_grad" = "success" ]; then
-            grad_ok=1
-          fi
-
-          echo "[finalize] strict initial=$init_strict strict retry=${retry_strict:-skipped} grad initial=$init_grad grad retry=${retry_grad:-skipped} retry enabled=$retry_enabled strict_ok=$strict_ok grad_ok=$grad_ok"
-
-          {
-            echo "## retry finalize"
-            echo "- strict initial: $init_strict"
-            echo "- strict retry: ${retry_strict:-skipped}"
-            echo "- graduation initial: $init_grad"
-            echo "- graduation retry: ${retry_grad:-skipped}"
-            echo "- retry enabled: $retry_enabled"
-            echo "- strict final ok: $strict_ok"
-            echo "- graduation final ok: $grad_ok"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [[ "$init_strict" != "success" && "$retry_strict" != "success" ]] || [[ "$init_grad" != "success" && "$retry_grad" != "success" ]]; then
-            echo "nightly failed after applying retry policy" >&2
-            exit 1
-          fi
+          python3 scripts/finalize-nightly-retry-result.py --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Publish failure triage summary (cause/language/repro)
         if: failure()

--- a/release-notes/0.5.3-nightly-finalizer-aggregation-f14-3.md
+++ b/release-notes/0.5.3-nightly-finalizer-aggregation-f14-3.md
@@ -1,0 +1,16 @@
+# F14-3 nightly finalizer / retry aggregation hardening
+
+## What changed
+- strict E2E and graduation steps now emit explicit `result=success|failure` outputs alongside GitHub Actions step outcomes
+- nightly finalization moved into `scripts/finalize-nightly-retry-result.py`
+- finalization now prefers explicit step results, falls back to runner outcomes only when needed, and treats retry-disabled paths as `skipped`
+
+## Why
+The previous finalizer depended only on `steps.<id>.outcome`. That works in the common case, but it is a weak source of truth for the exact retry command result and makes false-negative aggregation harder to reason about when retry metadata is absent or ambiguous.
+
+With explicit per-step results, a retry that actually turned green is aggregated as green even if workflow metadata is sparse or skipped on one side.
+
+## Validation
+- success if either initial or retry strict run succeeds, and either initial or retry graduation check succeeds
+- failure only if both strict attempts fail or both graduation attempts fail
+- retry-disabled paths are normalized to `skipped`, not treated as accidental failures

--- a/scripts/finalize-nightly-retry-result.py
+++ b/scripts/finalize-nightly-retry-result.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+from pathlib import Path
+
+SUCCESS_VALUES = {"success", "passed", "pass"}
+FAILURE_VALUES = {"failure", "failed", "cancelled", "canceled", "timed_out", "timed-out", "error"}
+SKIPPED_VALUES = {"", "skipped", "skip", "none", "null", "unset", "unknown"}
+
+
+def normalize(value: str | None, *, retry_enabled: bool, is_retry: bool) -> str:
+    raw = (value or "").strip().lower()
+    if raw in SUCCESS_VALUES:
+        return "success"
+    if raw in FAILURE_VALUES:
+        return "failure"
+    if raw in SKIPPED_VALUES:
+        if is_retry and not retry_enabled:
+            return "skipped"
+        return "skipped" if raw else ("skipped" if is_retry else "unknown")
+    return raw
+
+
+def resolve(result: str | None, outcome: str | None, *, retry_enabled: bool, is_retry: bool) -> str:
+    explicit = normalize(result, retry_enabled=retry_enabled, is_retry=is_retry)
+    if explicit in {"success", "failure"}:
+        return explicit
+    inferred = normalize(outcome, retry_enabled=retry_enabled, is_retry=is_retry)
+    if inferred in {"success", "failure", "skipped"}:
+        return inferred
+    if is_retry and not retry_enabled:
+        return "skipped"
+    return explicit
+
+
+def ok(*statuses: str) -> int:
+    return 1 if any(status == "success" for status in statuses) else 0
+
+
+def append_summary(path: Path, lines: list[str]) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--summary-file", required=True)
+    args = ap.parse_args()
+
+    retry_enabled = (os.environ.get("RETRY_ENABLED") or "").strip() == "1"
+
+    init_strict = resolve(
+        os.environ.get("INIT_STRICT_RESULT"),
+        os.environ.get("INIT_STRICT_OUTCOME"),
+        retry_enabled=retry_enabled,
+        is_retry=False,
+    )
+    retry_strict = resolve(
+        os.environ.get("RETRY_STRICT_RESULT"),
+        os.environ.get("RETRY_STRICT_OUTCOME"),
+        retry_enabled=retry_enabled,
+        is_retry=True,
+    )
+    init_grad = resolve(
+        os.environ.get("INIT_GRAD_RESULT"),
+        os.environ.get("INIT_GRAD_OUTCOME"),
+        retry_enabled=retry_enabled,
+        is_retry=False,
+    )
+    retry_grad = resolve(
+        os.environ.get("RETRY_GRAD_RESULT"),
+        os.environ.get("RETRY_GRAD_OUTCOME"),
+        retry_enabled=retry_enabled,
+        is_retry=True,
+    )
+
+    strict_ok = ok(init_strict, retry_strict)
+    grad_ok = ok(init_grad, retry_grad)
+
+    print(
+        f"[finalize] strict initial={init_strict} strict retry={retry_strict} "
+        f"grad initial={init_grad} grad retry={retry_grad} retry enabled={int(retry_enabled)} "
+        f"strict_ok={strict_ok} grad_ok={grad_ok}"
+    )
+
+    append_summary(
+        Path(args.summary_file),
+        [
+            "## retry finalize",
+            f"- strict initial: {init_strict}",
+            f"- strict retry: {retry_strict}",
+            f"- graduation initial: {init_grad}",
+            f"- graduation retry: {retry_grad}",
+            f"- retry enabled: {int(retry_enabled)}",
+            f"- strict final ok: {strict_ok}",
+            f"- graduation final ok: {grad_ok}",
+        ],
+    )
+
+    if not strict_ok or not grad_ok:
+        print("nightly failed after applying retry policy", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- move nightly retry finalization into an explicit aggregation script
- record strict/graduation command results as step outputs and prefer them over workflow metadata
- add F14-3 note documenting the false-negative hardening

## Testing
- python3 -m py_compile scripts/finalize-nightly-retry-result.py
- python3 truth-table checks for success/failure/skip aggregation
- python3 with PyYAML to parse .github/workflows/nightly-strict-lsp.yml