### PR TITLE
Add F14-6A nightly rerun status memo

### DIFF
--- a/release-notes/0.5.4-nightly-rerun-status-f14-6a.md
+++ b/release-notes/0.5.4-nightly-rerun-status-f14-6a.md
@@ -1,0 +1,65 @@
+# F14-6A nightly strict real-LSP rerun status memo
+
+- Run ID: `a9663131-953f-4db8-aaa8-896dfada8816`
+- Task: rerun strict real-LSP nightly and record whether it is currently green or still failing
+- Workflow: `.github/workflows/nightly-strict-lsp.yml`
+- Branch rerun target: `main`
+- Actions run: [24139642236](https://github.com/n01e0/dimpact/actions/runs/24139642236)
+- Created (UTC): `2026-04-08T14:04:26Z`
+- Updated (UTC): `2026-04-08T14:09:51Z`
+- Head SHA: `6080e990b9a67fbc70dc9aec438ad829ea45c3cb`
+
+## Current status
+
+**Not green.**
+The rerun still finished with workflow conclusion `failure`.
+This is not an install-only false red: the strict suite stayed red both before and after retry, while the graduation check stayed green both times.
+
+| check | initial | retry |
+| --- | --- | --- |
+| strict real-LSP engine_lsp suite | `failure` | `failure` |
+| LSP graduation auto-check | `success` | `success` |
+| workflow final result | `failure` | n/a |
+
+The finalizer log shows the same split explicitly:
+
+```text
+[finalize] strict initial=failure strict retry=failure grad initial=success grad retry=success retry enabled=1 strict_ok=0 grad_ok=1
+nightly failed after applying retry policy
+```
+
+## What is still failing in this rerun
+
+From `nightly-failure-triage.md` and `nightly-flaky-classification.md` in the uploaded `nightly-strict-lsp-execution-logs` artifact:
+
+### Unresolved failure buckets
+
+| category | count |
+| --- | ---: |
+| install | 0 |
+| retry_absorbed | 0 |
+| startup | 24 |
+| logic | 72 |
+| capability | 0 |
+| timeout | 25 |
+
+### Failing lanes that remained red after retry
+
+- `java/{callers,callees,both}`
+  - `lsp initialize timeout or invalid response`
+  - classified as `startup` and `timeout`
+- `javascript/{callers,callees,both}`
+  - `lsp changed_symbols returned no symbols; policy=strict language=Auto`
+  - classified as `logic`
+- `typescript/{callers,callees,both}`
+  - `lsp changed_symbols returned no symbols; policy=strict language=Auto`
+  - classified as `logic`
+- `ruby/{callers,callees,both}`
+  - `lsp changed_symbols returned no symbols; policy=strict language=Auto`
+  - classified as `logic`
+
+## What this rerun does show
+
+- Ruby install/preflight is no longer the blocker in this rerun, because `install=0` and the workflow reached strict execution for Ruby.
+- The remaining nightly red state is an unresolved strict-suite failure set, not a forced-green task and not a memo that pretends the lane recovered.
+- So the honest current memo is: **nightly strict real-LSP is still failing as of run `24139642236`**.


### PR DESCRIPTION
## Summary
- rerun the strict real-LSP nightly workflow on main
- record the current outcome honestly in a release-note memo
- capture the unresolved failure buckets and affected lanes from run 24139642236

## Testing
- GitHub Actions PR checks

## Workflow rerun
- https://github.com/n01e0/dimpact/actions/runs/24139642236