### PR TITLE
Use representative explanations in slice witnesses

### DIFF
--- a/src/bin/dimpact.rs
+++ b/src/bin/dimpact.rs
@@ -9,6 +9,7 @@ use dimpact::dfg_to_dot;
 use dimpact::engine::{AutoPolicy, EngineKind, make_engine_with_auto_policy};
 use dimpact::impact::{
     ImpactBridgeExecutionFamily, ImpactBridgeExecutionStepCompact, ImpactBridgeExecutionStepFamily,
+    ImpactSliceRepresentativeExplanationMetadata,
 };
 use dimpact::ir::SymbolId;
 use dimpact::ir::reference::{EdgeCertainty, EdgeProvenance, RefKind, Reference, SymbolIndex};
@@ -1886,6 +1887,28 @@ struct RepresentativeCandidate {
     representative: StitchedChainRepresentative,
 }
 
+fn to_impact_representative_explanation(
+    representative: &StitchedChainRepresentative,
+) -> ImpactSliceRepresentativeExplanationMetadata {
+    ImpactSliceRepresentativeExplanationMetadata {
+        family_bucket: Some(representative.family_bucket.as_str().to_string()),
+        closure_target_key: Some(representative.closure_target_key.clone()),
+        duplicate_key: Some(representative.duplicate_key.clone()),
+        budget_key: Some(representative.budget_key.clone()),
+        winner_reason_codes: representative.explanation.winner_reason_codes.clone(),
+        loser_reason_codes: representative.explanation.loser_reason_codes.clone(),
+        closure_summary: Some(representative.explanation.closure_summary.clone()),
+        family_summary: Some(representative.explanation.family_summary.clone()),
+        budget_summary: Some(representative.explanation.budget_summary.clone()),
+        duplicate_summary: representative.explanation.duplicate_summary.clone(),
+        winning_bridge_execution_chain_compact: representative
+            .winning_bridge_execution_chain_compact
+            .clone(),
+        observed_supporting_steps_compact: representative.observed_supporting_steps_compact.clone(),
+        negative_chain_signals: representative.negative_chain_signals.clone(),
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct SliceSelectionFileState {
     scopes: ImpactSliceScopes,
@@ -2898,6 +2921,7 @@ fn make_candidate_reason_with_tier(
     candidate: &Tier2Candidate,
     tier: SliceSelectionTier,
 ) -> ImpactSliceReasonMetadata {
+    let representative = make_stitched_chain_representative(seed_symbol_id, candidate, tier);
     ImpactSliceReasonMetadata {
         seed_symbol_id: seed_symbol_id.to_string(),
         tier: slice_selection_tier_value(tier),
@@ -2906,6 +2930,7 @@ fn make_candidate_reason_with_tier(
         via_path: Some(candidate.via_path.clone()),
         bridge_kind: candidate.bridge_kind,
         scoring: Some(candidate.scoring.clone()),
+        representative_explanation: Some(to_impact_representative_explanation(&representative)),
     }
 }
 
@@ -2933,6 +2958,7 @@ fn make_pruned_candidate_with_tier(
     prune_reason: ImpactSlicePruneReason,
     tier: SliceSelectionTier,
 ) -> dimpact::ImpactSlicePrunedCandidate {
+    let representative = make_stitched_chain_representative(seed_symbol_id, candidate, tier);
     let compact_explanation = match prune_reason {
         ImpactSlicePruneReason::SuppressedBeforeAdmit => {
             let suppressor = if candidate_is_weak_ruby_require_relative(candidate) {
@@ -2966,6 +2992,7 @@ fn make_pruned_candidate_with_tier(
         prune_reason,
         scoring: Some(candidate.scoring.clone()),
         compact_explanation,
+        representative_explanation: Some(to_impact_representative_explanation(&representative)),
     }
 }
 
@@ -3404,6 +3431,7 @@ fn plan_bounded_slice(
     for seed in seeds {
         let mut seed_selection = SliceSelectionAccumulator::default();
         let root_reason = ImpactSliceReasonMetadata {
+            representative_explanation: None,
             seed_symbol_id: seed.id.0.clone(),
             tier: slice_selection_tier_value(SliceSelectionTier::Root),
             kind: root_reason_kind,
@@ -3433,6 +3461,7 @@ fn plan_bounded_slice(
                 seed_selection.add_reason(
                     boundary_file,
                     ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: slice_selection_tier_value(SliceSelectionTier::DirectBoundary),
                         kind: boundary.kind,
@@ -5156,6 +5185,7 @@ fn caller() -> i32 {
         assert_eq!(
             left_leaf.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -5182,6 +5212,7 @@ fn caller() -> i32 {
         assert_eq!(
             right_leaf.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -5310,6 +5341,7 @@ fn caller() -> i32 {
         assert_eq!(
             leaf_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -5331,6 +5363,7 @@ fn caller() -> i32 {
         assert_eq!(
             plan.slice_selection.pruned_candidates,
             vec![dimpact::ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "zzz_final_helper.rs".to_string(),
                 tier: 2,
@@ -5409,6 +5442,7 @@ fn caller() -> i32 {
         assert_eq!(
             value_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -5498,6 +5532,7 @@ fn caller() -> i32 {
         assert_eq!(
             out_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::BridgeContinuationFile,
@@ -5598,6 +5633,7 @@ fn caller() -> i32 {
         assert_eq!(
             value_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -5624,6 +5660,7 @@ fn caller() -> i32 {
         assert_eq!(
             out_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::BridgeContinuationFile,
@@ -5650,6 +5687,7 @@ fn caller() -> i32 {
         assert_eq!(
             final_leaf_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::BridgeContinuationFile,
@@ -5744,6 +5782,7 @@ fn caller() -> i32 {
         assert_eq!(
             a_final_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::BridgeContinuationFile,
@@ -6022,6 +6061,7 @@ fn caller() -> i32 {
         assert_eq!(
             step_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -6191,6 +6231,7 @@ fn caller() -> i32 {
         assert_eq!(
             steady_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -6227,6 +6268,7 @@ fn caller() -> i32 {
         assert_eq!(
             plan.slice_selection.pruned_candidates,
             vec![dimpact::ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "plain.rs".to_string(),
                 tier: 2,
@@ -6345,6 +6387,7 @@ fn caller() -> i32 {
         assert_eq!(
             leaf_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -6366,6 +6409,7 @@ fn caller() -> i32 {
         assert_eq!(
             plan.slice_selection.pruned_candidates,
             vec![dimpact::ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "lib/zzz_helper.rb".to_string(),
                 tier: 2,
@@ -6535,6 +6579,7 @@ fn caller() -> i32 {
         assert_eq!(
             leaf_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -6556,6 +6601,7 @@ fn caller() -> i32 {
         assert_eq!(
             plan.slice_selection.pruned_candidates,
             vec![dimpact::ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "shared.rs".to_string(),
                 tier: 2,
@@ -6648,6 +6694,7 @@ fn caller() -> i32 {
         assert_eq!(
             leaf_file.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -6666,6 +6713,7 @@ fn caller() -> i32 {
         assert_eq!(
             plan.slice_selection.pruned_candidates,
             vec![dimpact::ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "lib/runtime.rb".to_string(),
                 tier: 2,
@@ -6966,6 +7014,7 @@ fn caller() -> i32 {
         assert_eq!(
             runtime_file_meta.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::ModuleCompanionFile,
@@ -7137,6 +7186,7 @@ fn caller() -> i32 {
         assert_eq!(
             main.reasons,
             vec![ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 tier: 0,
                 kind: ImpactSliceReasonKind::SeedFile,

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -89,7 +89,7 @@ pub struct ImpactSliceScopes {
     pub explanation: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactSliceReasonMetadata {
     pub seed_symbol_id: String,
     pub tier: u8,
@@ -102,6 +102,63 @@ pub struct ImpactSliceReasonMetadata {
     pub bridge_kind: Option<ImpactSliceBridgeKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scoring: Option<ImpactSliceCandidateScoringSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub representative_explanation: Option<ImpactSliceRepresentativeExplanationMetadata>,
+}
+
+impl PartialEq for ImpactSliceReasonMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.seed_symbol_id == other.seed_symbol_id
+            && self.tier == other.tier
+            && self.kind == other.kind
+            && self.via_symbol_id == other.via_symbol_id
+            && self.via_path == other.via_path
+            && self.bridge_kind == other.bridge_kind
+            && self.scoring == other.scoring
+    }
+}
+
+impl Eq for ImpactSliceReasonMetadata {}
+
+impl PartialOrd for ImpactSliceReasonMetadata {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ImpactSliceReasonMetadata {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (
+            &self.seed_symbol_id,
+            self.tier,
+            self.kind,
+            &self.via_symbol_id,
+            &self.via_path,
+            self.bridge_kind,
+            &self.scoring,
+        )
+            .cmp(&(
+                &other.seed_symbol_id,
+                other.tier,
+                other.kind,
+                &other.via_symbol_id,
+                &other.via_path,
+                other.bridge_kind,
+                &other.scoring,
+            ))
+    }
+}
+
+impl std::hash::Hash for ImpactSliceReasonMetadata {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.seed_symbol_id.hash(state);
+        self.tier.hash(state);
+        self.kind.hash(state);
+        self.via_symbol_id.hash(state);
+        self.via_path.hash(state);
+        self.bridge_kind.hash(state);
+        self.scoring.hash(state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -238,7 +295,7 @@ pub struct ImpactSliceScoreTuple {
     pub lexical_tiebreak: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactSlicePrunedCandidate {
     pub seed_symbol_id: String,
     pub path: String,
@@ -255,6 +312,75 @@ pub struct ImpactSlicePrunedCandidate {
     pub scoring: Option<ImpactSliceCandidateScoringSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub representative_explanation: Option<ImpactSliceRepresentativeExplanationMetadata>,
+}
+
+impl PartialEq for ImpactSlicePrunedCandidate {
+    fn eq(&self, other: &Self) -> bool {
+        self.seed_symbol_id == other.seed_symbol_id
+            && self.path == other.path
+            && self.tier == other.tier
+            && self.kind == other.kind
+            && self.via_symbol_id == other.via_symbol_id
+            && self.via_path == other.via_path
+            && self.bridge_kind == other.bridge_kind
+            && self.prune_reason == other.prune_reason
+            && self.scoring == other.scoring
+            && self.compact_explanation == other.compact_explanation
+    }
+}
+
+impl Eq for ImpactSlicePrunedCandidate {}
+
+impl PartialOrd for ImpactSlicePrunedCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ImpactSlicePrunedCandidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (
+            &self.seed_symbol_id,
+            &self.path,
+            self.tier,
+            self.kind,
+            &self.via_symbol_id,
+            &self.via_path,
+            self.bridge_kind,
+            self.prune_reason,
+            &self.scoring,
+            &self.compact_explanation,
+        )
+            .cmp(&(
+                &other.seed_symbol_id,
+                &other.path,
+                other.tier,
+                other.kind,
+                &other.via_symbol_id,
+                &other.via_path,
+                other.bridge_kind,
+                other.prune_reason,
+                &other.scoring,
+                &other.compact_explanation,
+            ))
+    }
+}
+
+impl std::hash::Hash for ImpactSlicePrunedCandidate {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.seed_symbol_id.hash(state);
+        self.path.hash(state);
+        self.tier.hash(state);
+        self.kind.hash(state);
+        self.via_symbol_id.hash(state);
+        self.via_path.hash(state);
+        self.bridge_kind.hash(state);
+        self.prune_reason.hash(state);
+        self.scoring.hash(state);
+        self.compact_explanation.hash(state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -378,7 +504,7 @@ pub struct ImpactWitnessSliceFileContext {
     pub selected_vs_pruned_reasons: Vec<ImpactWitnessSliceSelectedVsPrunedReason>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum ImpactBridgeExecutionFamily {
     ReturnContinuation,
@@ -388,7 +514,7 @@ pub enum ImpactBridgeExecutionFamily {
     NestedMultiInputContinuation,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum ImpactBridgeExecutionStepFamily {
     CallsiteInputBinding,
@@ -398,7 +524,7 @@ pub enum ImpactBridgeExecutionStepFamily {
     RequireRelativeLoad,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImpactBridgeExecutionStepCompact {
     pub family: ImpactBridgeExecutionFamily,
     pub step_family: ImpactBridgeExecutionStepFamily,
@@ -411,6 +537,36 @@ pub struct ImpactBridgeExecutionStepCompact {
     pub reason_kind: Option<ImpactSliceReasonKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct ImpactSliceRepresentativeExplanationMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family_bucket: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closure_target_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duplicate_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub winner_reason_codes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub loser_reason_codes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closure_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duplicate_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub winning_bridge_execution_chain_compact: Vec<ImpactBridgeExecutionStepCompact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub observed_supporting_steps_compact: Vec<ImpactBridgeExecutionStepCompact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub negative_chain_signals: Vec<String>,
 }
 
 type ImpactBridgeExecutionStepKey = (
@@ -1141,6 +1297,30 @@ fn selected_reason_matches_pruned_candidate(
     reason: &ImpactSliceReasonMetadata,
     candidate: &ImpactSlicePrunedCandidate,
 ) -> bool {
+    if let (Some(selected), Some(pruned)) = (
+        reason.representative_explanation.as_ref(),
+        candidate.representative_explanation.as_ref(),
+    ) {
+        if matches!(
+            candidate.prune_reason,
+            ImpactSlicePruneReason::WeakerSameChainDuplicate
+        ) && selected.duplicate_key.is_some()
+            && selected.duplicate_key == pruned.duplicate_key
+        {
+            return true;
+        }
+        if matches!(
+            candidate.prune_reason,
+            ImpactSlicePruneReason::BridgeBudgetExhausted
+        ) && ((selected.budget_key.is_some() && selected.budget_key == pruned.budget_key)
+            || (selected.family_bucket.is_some()
+                && selected.family_bucket == pruned.family_bucket
+                && reason.kind == candidate.kind))
+        {
+            return true;
+        }
+    }
+
     matches!(
         reason.kind,
         ImpactSliceReasonKind::BridgeCompletionFile | ImpactSliceReasonKind::BridgeContinuationFile
@@ -1156,6 +1336,38 @@ fn selected_reason_matches_pruned_candidate(
         && reason.kind == candidate.kind
         && reason.via_symbol_id == candidate.via_symbol_id
         && reason.via_path == candidate.via_path
+}
+
+fn representative_selected_vs_pruned_summary(
+    selected: Option<&ImpactSliceRepresentativeExplanationMetadata>,
+    pruned: Option<&ImpactSliceRepresentativeExplanationMetadata>,
+) -> Option<String> {
+    let mut parts = Vec::new();
+
+    if let Some(selected) = selected {
+        if let Some(summary) = selected.closure_summary.as_ref() {
+            parts.push(summary.clone());
+        }
+        if let Some(summary) = selected.family_summary.as_ref() {
+            parts.push(summary.clone());
+        }
+        if !selected.winner_reason_codes.is_empty() {
+            parts.push(format!("winner={}", selected.winner_reason_codes.join(",")));
+        }
+    }
+
+    if let Some(pruned) = pruned {
+        if let Some(summary) = pruned.duplicate_summary.as_ref() {
+            parts.push(summary.clone());
+        } else if let Some(summary) = pruned.budget_summary.as_ref() {
+            parts.push(summary.clone());
+        }
+        if !pruned.loser_reason_codes.is_empty() {
+            parts.push(format!("loser={}", pruned.loser_reason_codes.join(",")));
+        }
+    }
+
+    (!parts.is_empty()).then(|| parts.join("; "))
 }
 
 fn build_selected_vs_pruned_reasons(
@@ -1187,6 +1399,10 @@ fn build_selected_vs_pruned_reasons(
                 selected_vs_pruned_winning_support(selected_scoring, pruned_scoring);
             let losing_side_reason =
                 selected_vs_pruned_losing_side_reason(selected_scoring, pruned_scoring);
+            let representative_summary = representative_selected_vs_pruned_summary(
+                reason.representative_explanation.as_ref(),
+                candidate.representative_explanation.as_ref(),
+            );
             reasons.push(ImpactWitnessSliceSelectedVsPrunedReason {
                 via_symbol_id: reason.via_symbol_id.clone(),
                 via_path: reason.via_path.clone(),
@@ -1199,16 +1415,18 @@ fn build_selected_vs_pruned_reasons(
                 winning_support: winning_support.clone(),
                 losing_side_reason: losing_side_reason.clone(),
                 compact_explanation: candidate.compact_explanation.clone(),
-                summary: selected_vs_pruned_summary(
-                    selected_path,
-                    &candidate.path,
-                    selected_better_by,
-                    selected_scoring,
-                    pruned_scoring,
-                    winning_primary_evidence_kinds.as_deref(),
-                    winning_support.as_ref(),
-                    losing_side_reason.as_deref(),
-                ),
+                summary: representative_summary.unwrap_or_else(|| {
+                    selected_vs_pruned_summary(
+                        selected_path,
+                        &candidate.path,
+                        selected_better_by,
+                        selected_scoring,
+                        pruned_scoring,
+                        winning_primary_evidence_kinds.as_deref(),
+                        winning_support.as_ref(),
+                        losing_side_reason.as_deref(),
+                    )
+                }),
             });
         }
     }
@@ -1499,6 +1717,56 @@ fn bridge_execution_representative_family(
     }
 }
 
+fn build_bridge_execution_provenance_from_representatives(
+    slice_context: &ImpactWitnessSliceContext,
+    provenance_chain: &[EdgeProvenance],
+) -> Option<(
+    Option<ImpactBridgeExecutionFamily>,
+    Vec<ImpactBridgeExecutionStepCompact>,
+    Vec<ImpactBridgeExecutionStepCompact>,
+)> {
+    let mut winning_steps = Vec::new();
+    let mut seen_winning_steps = HashSet::new();
+    let mut supporting_steps = Vec::new();
+    let mut seen_supporting_steps = HashSet::new();
+
+    for file_context in &slice_context.selected_files_on_path {
+        for reason in file_context
+            .selection_reasons
+            .iter()
+            .chain(file_context.seed_reasons.iter())
+        {
+            let Some(representative) = reason.representative_explanation.as_ref() else {
+                continue;
+            };
+            for step in &representative.winning_bridge_execution_chain_compact {
+                push_unique_bridge_execution_step(
+                    &mut winning_steps,
+                    &mut seen_winning_steps,
+                    step.clone(),
+                );
+            }
+            for step in &representative.observed_supporting_steps_compact {
+                push_unique_bridge_execution_step(
+                    &mut supporting_steps,
+                    &mut seen_supporting_steps,
+                    step.clone(),
+                );
+            }
+        }
+    }
+
+    if winning_steps.is_empty() && supporting_steps.is_empty() {
+        return None;
+    }
+
+    let representative_family =
+        bridge_execution_representative_family(&winning_steps, provenance_chain).or_else(|| {
+            bridge_execution_representative_family(&supporting_steps, provenance_chain)
+        });
+    Some((representative_family, winning_steps, supporting_steps))
+}
+
 fn build_bridge_execution_provenance_compact(
     slice_context: &ImpactWitnessSliceContext,
     provenance_chain: &[EdgeProvenance],
@@ -1507,6 +1775,12 @@ fn build_bridge_execution_provenance_compact(
     Vec<ImpactBridgeExecutionStepCompact>,
     Vec<ImpactBridgeExecutionStepCompact>,
 ) {
+    if let Some(representative_steps) =
+        build_bridge_execution_provenance_from_representatives(slice_context, provenance_chain)
+    {
+        return representative_steps;
+    }
+
     let mut winning_steps = Vec::new();
     let mut seen_winning_steps = HashSet::new();
     let mut supporting_steps = Vec::new();
@@ -2986,6 +3260,7 @@ fn foo() { bar(); }
         let mut out = compute_impact(std::slice::from_ref(&seed), &index, &refs, &opts);
 
         let wrapper_seed_reason = ImpactSliceReasonMetadata {
+            representative_explanation: None,
             seed_symbol_id: seed.id.0.clone(),
             tier: 2,
             kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -2995,6 +3270,7 @@ fn foo() { bar(); }
             scoring: None,
         };
         let wrapper_other_reason = ImpactSliceReasonMetadata {
+            representative_explanation: None,
             seed_symbol_id: "rust:other.rs:fn:other:1".to_string(),
             tier: 1,
             kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -3014,6 +3290,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 0,
                         kind: ImpactSliceReasonKind::ChangedFile,
@@ -3040,6 +3317,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 1,
                         kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -3057,6 +3335,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 3,
                         kind: ImpactSliceReasonKind::ModuleCompanionFile,
@@ -3086,6 +3365,7 @@ fn foo() { bar(); }
                         path: "main.rs".to_string(),
                         witness_hops: vec![0],
                         selection_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 0,
                             kind: ImpactSliceReasonKind::ChangedFile,
@@ -3095,6 +3375,7 @@ fn foo() { bar(); }
                             scoring: None,
                         }],
                         seed_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 0,
                             kind: ImpactSliceReasonKind::ChangedFile,
@@ -3110,6 +3391,7 @@ fn foo() { bar(); }
                         witness_hops: vec![0, 1],
                         selection_reasons: vec![wrapper_seed_reason, wrapper_other_reason,],
                         seed_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 2,
                             kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3124,6 +3406,7 @@ fn foo() { bar(); }
                         path: "callee.rs".to_string(),
                         witness_hops: vec![1],
                         selection_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 1,
                             kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -3133,6 +3416,7 @@ fn foo() { bar(); }
                             scoring: None,
                         }],
                         seed_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 1,
                             kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -3262,6 +3546,7 @@ fn foo() { bar(); }
         let mut out = compute_impact(std::slice::from_ref(&seed), &index, &refs, &opts);
 
         let selected_reason = ImpactSliceReasonMetadata {
+            representative_explanation: None,
             seed_symbol_id: seed.id.0.clone(),
             tier: 2,
             kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3301,6 +3586,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 0,
                         kind: ImpactSliceReasonKind::ChangedFile,
@@ -3318,6 +3604,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 1,
                         kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -3338,6 +3625,7 @@ fn foo() { bar(); }
                 },
             ],
             pruned_candidates: vec![ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: seed.id.0.clone(),
                 path: "aaa_helper.rs".to_string(),
                 tier: 2,
@@ -3426,6 +3714,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "lib/leaf.rb",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed_symbol_id.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3459,6 +3748,7 @@ fn foo() { bar(); }
                 }),
             }],
             &[ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id,
                 path: "lib/helper.rb".to_string(),
                 tier: 2,
@@ -3527,6 +3817,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "leaf.rs",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed_symbol_id.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3556,6 +3847,7 @@ fn foo() { bar(); }
                 }),
             }],
             &[ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id,
                 path: "aaa_helper.rs".to_string(),
                 tier: 2,
@@ -3616,6 +3908,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "leaf.rs",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed_symbol_id.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3645,6 +3938,7 @@ fn foo() { bar(); }
                 }),
             }],
             &[ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id,
                 path: "zzz_final_helper.rs".to_string(),
                 tier: 2,
@@ -3705,6 +3999,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "leaf.rs",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: "rust:main.rs:fn:caller:5".to_string(),
                 tier: 3,
                 kind: ImpactSliceReasonKind::BridgeContinuationFile,
@@ -3737,6 +4032,7 @@ fn foo() { bar(); }
                 }),
             }],
             &[ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id: "rust:main.rs:fn:caller:5".to_string(),
                 path: "alt_leaf.rs".to_string(),
                 tier: 3,
@@ -3789,6 +4085,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "step.rs",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed_symbol_id.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3822,6 +4119,7 @@ fn foo() { bar(); }
                 }),
             }],
             &[ImpactSlicePrunedCandidate {
+                representative_explanation: None,
                 seed_symbol_id,
                 path: "later.rs".to_string(),
                 tier: 2,
@@ -3889,6 +4187,7 @@ fn foo() { bar(); }
         let reasons = build_selected_vs_pruned_reasons(
             "lib/route_runtime.rb",
             &[ImpactSliceReasonMetadata {
+                representative_explanation: None,
                 seed_symbol_id: seed_symbol_id.clone(),
                 tier: 2,
                 kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -3922,6 +4221,7 @@ fn foo() { bar(); }
             }],
             &[
                 ImpactSlicePrunedCandidate {
+                    representative_explanation: None,
                     seed_symbol_id: seed_symbol_id.clone(),
                     path: "lib/route_runtime.rb".to_string(),
                     tier: 2,
@@ -3956,6 +4256,7 @@ fn foo() { bar(); }
                     ),
                 },
                 ImpactSlicePrunedCandidate {
+                    representative_explanation: None,
                     seed_symbol_id,
                     path: "lib/fallback_runtime.rb".to_string(),
                     tier: 2,
@@ -4153,6 +4454,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 0,
                         kind: ImpactSliceReasonKind::SeedFile,
@@ -4170,6 +4472,7 @@ fn foo() { bar(); }
                         explanation: false,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 2,
                         kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -4187,6 +4490,7 @@ fn foo() { bar(); }
                         explanation: true,
                     },
                     reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: seed.id.0.clone(),
                         tier: 1,
                         kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -4215,6 +4519,7 @@ fn foo() { bar(); }
                         path: "main.rs".to_string(),
                         witness_hops: vec![0],
                         selection_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 0,
                             kind: ImpactSliceReasonKind::SeedFile,
@@ -4224,6 +4529,7 @@ fn foo() { bar(); }
                             scoring: None,
                         }],
                         seed_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 0,
                             kind: ImpactSliceReasonKind::SeedFile,
@@ -4238,6 +4544,7 @@ fn foo() { bar(); }
                         path: "callee.rs".to_string(),
                         witness_hops: vec![1],
                         selection_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 1,
                             kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -4247,6 +4554,7 @@ fn foo() { bar(); }
                             scoring: None,
                         }],
                         seed_reasons: vec![ImpactSliceReasonMetadata {
+                            representative_explanation: None,
                             seed_symbol_id: seed.id.0.clone(),
                             tier: 1,
                             kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -4289,6 +4597,7 @@ fn foo() { bar(); }
                     witness_hops: vec![0],
                     selection_reasons: vec![],
                     seed_reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
                         tier: 1,
                         kind: ImpactSliceReasonKind::DirectCalleeFile,
@@ -4304,6 +4613,7 @@ fn foo() { bar(); }
                     witness_hops: vec![1],
                     selection_reasons: vec![],
                     seed_reasons: vec![ImpactSliceReasonMetadata {
+                        representative_explanation: None,
                         seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
                         tier: 2,
                         kind: ImpactSliceReasonKind::BridgeCompletionFile,
@@ -4685,5 +4995,193 @@ fn foo() { bar(); }
         let round_tripped: ImpactSliceCandidateScoringSummary =
             serde_json::from_value(value).expect("deserialize scoring summary");
         assert_eq!(round_tripped, scoring);
+    }
+
+    #[test]
+    fn selected_vs_pruned_prefers_representative_explanation_for_same_chain_duplicate() {
+        let reasons = build_selected_vs_pruned_reasons(
+            "lib/alias_leaf.rb",
+            &[ImpactSliceReasonMetadata {
+                representative_explanation: Some(ImpactSliceRepresentativeExplanationMetadata {
+                    family_bucket: Some("alias_result".to_string()),
+                    closure_target_key: Some(
+                        "ruby:lib/alias_leaf.rb:method:alias_finish:3".to_string(),
+                    ),
+                    duplicate_key: Some("dup-key".to_string()),
+                    budget_key: Some("dup-key".to_string()),
+                    winner_reason_codes: vec!["file_first_candidate_projection".to_string()],
+                    loser_reason_codes: vec![],
+                    closure_summary: Some(
+                        "file-first candidate currently closes at ruby:lib/alias_leaf.rb:method:alias_finish:3"
+                            .to_string(),
+                    ),
+                    family_summary: Some("family bucket=alias_result".to_string()),
+                    budget_summary: Some("representative budget key=dup-key".to_string()),
+                    duplicate_summary: Some("representative duplicate key=dup-key".to_string()),
+                    winning_bridge_execution_chain_compact: vec![],
+                    observed_supporting_steps_compact: vec![],
+                    negative_chain_signals: vec![],
+                }),
+                seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("ruby:lib/service.rb:method:bounce:3".to_string()),
+                via_path: Some("lib/service.rb".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::AliasContinuation,
+                    primary_evidence_kinds: vec![ImpactSliceEvidenceKind::AliasChain],
+                    secondary_evidence_kinds: vec![],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 1,
+                        primary_evidence_count: 1,
+                        secondary_evidence_count: 0,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 1,
+                        call_position_rank: 3,
+                        lexical_tiebreak: "lib/alias_leaf.rb".to_string(),
+                    },
+                    support: None,
+                }),
+            }],
+            &[ImpactSlicePrunedCandidate {
+                representative_explanation: Some(ImpactSliceRepresentativeExplanationMetadata {
+                    family_bucket: Some("alias_result".to_string()),
+                    closure_target_key: Some(
+                        "ruby:lib/alias_leaf.rb:method:alias_finish:3".to_string(),
+                    ),
+                    duplicate_key: Some("dup-key".to_string()),
+                    budget_key: Some("dup-key".to_string()),
+                    winner_reason_codes: vec![],
+                    loser_reason_codes: vec!["same_chain_duplicate".to_string()],
+                    closure_summary: Some(
+                        "file-first candidate currently closes at ruby:lib/alias_leaf.rb:method:alias_finish:3"
+                            .to_string(),
+                    ),
+                    family_summary: Some("family bucket=alias_result".to_string()),
+                    budget_summary: Some("representative budget key=dup-key".to_string()),
+                    duplicate_summary: Some("representative duplicate key=dup-key".to_string()),
+                    winning_bridge_execution_chain_compact: vec![],
+                    observed_supporting_steps_compact: vec![],
+                    negative_chain_signals: vec![],
+                }),
+                seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
+                path: "lib/noisy_alias_leaf.rb".to_string(),
+                tier: 2,
+                kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                via_symbol_id: Some("ruby:lib/service.rb:method:bounce:3".to_string()),
+                via_path: Some("lib/service.rb".to_string()),
+                bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                prune_reason: ImpactSlicePruneReason::WeakerSameChainDuplicate,
+                scoring: Some(ImpactSliceCandidateScoringSummary {
+                    source_kind: ImpactSliceCandidateSourceKind::GraphSecondHop,
+                    lane: ImpactSliceCandidateLane::AliasContinuation,
+                    primary_evidence_kinds: vec![ImpactSliceEvidenceKind::AliasChain],
+                    secondary_evidence_kinds: vec![],
+                    negative_evidence_kinds: vec![],
+                    score_tuple: ImpactSliceScoreTuple {
+                        source_rank: 0,
+                        lane_rank: 1,
+                        primary_evidence_count: 1,
+                        secondary_evidence_count: 0,
+                        negative_evidence_count: 0,
+                        semantic_support_rank: 0,
+                        call_position_rank: 2,
+                        lexical_tiebreak: "lib/noisy_alias_leaf.rb".to_string(),
+                    },
+                    support: None,
+                }),
+                compact_explanation: Some(
+                    "suppressed_before_admit=weaker_same_chain_duplicate".to_string(),
+                ),
+            }],
+        );
+
+        assert_eq!(reasons.len(), 1);
+        assert!(
+            reasons[0]
+                .summary
+                .contains("representative duplicate key=dup-key")
+        );
+        assert!(
+            reasons[0]
+                .summary
+                .contains("winner=file_first_candidate_projection")
+        );
+    }
+
+    #[test]
+    fn build_bridge_execution_provenance_compact_prefers_representative_winning_chain() {
+        let winning_step = ImpactBridgeExecutionStepCompact {
+            family: ImpactBridgeExecutionFamily::AliasResultStitch,
+            step_family: ImpactBridgeExecutionStepFamily::AliasResultStitch,
+            anchor_symbol_id: "ruby:lib/service.rb:method:bounce:3".to_string(),
+            anchor_path: Some("lib/service.rb".to_string()),
+            bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+            reason_kind: Some(ImpactSliceReasonKind::BridgeCompletionFile),
+            summary: Some("winning representative step".to_string()),
+        };
+        let supporting_step = ImpactBridgeExecutionStepCompact {
+            family: ImpactBridgeExecutionFamily::MixedRequireRelativeAliasStitch,
+            step_family: ImpactBridgeExecutionStepFamily::RequireRelativeLoad,
+            anchor_symbol_id: "ruby:lib/service.rb:method:bounce:3".to_string(),
+            anchor_path: Some("lib/service.rb".to_string()),
+            bridge_kind: Some(ImpactSliceBridgeKind::RequireRelativeChain),
+            reason_kind: Some(ImpactSliceReasonKind::BridgeCompletionFile),
+            summary: Some("supporting representative step".to_string()),
+        };
+        let slice_context = ImpactWitnessSliceContext {
+            seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
+            selected_files_on_path: vec![ImpactWitnessSliceFileContext {
+                path: "lib/alias_leaf.rb".to_string(),
+                witness_hops: vec![1],
+                selection_reasons: vec![ImpactSliceReasonMetadata {
+                    representative_explanation: Some(
+                        ImpactSliceRepresentativeExplanationMetadata {
+                            family_bucket: Some("alias_result".to_string()),
+                            closure_target_key: Some(
+                                "ruby:lib/alias_leaf.rb:method:alias_finish:3".to_string(),
+                            ),
+                            duplicate_key: Some("dup-key".to_string()),
+                            budget_key: Some("budget-key".to_string()),
+                            winner_reason_codes: vec![
+                                "file_first_candidate_projection".to_string(),
+                            ],
+                            loser_reason_codes: vec![],
+                            closure_summary: Some("representative winner".to_string()),
+                            family_summary: Some("family bucket=alias_result".to_string()),
+                            budget_summary: Some(
+                                "representative budget key=budget-key".to_string(),
+                            ),
+                            duplicate_summary: Some(
+                                "representative duplicate key=dup-key".to_string(),
+                            ),
+                            winning_bridge_execution_chain_compact: vec![winning_step.clone()],
+                            observed_supporting_steps_compact: vec![supporting_step.clone()],
+                            negative_chain_signals: vec![],
+                        },
+                    ),
+                    seed_symbol_id: "ruby:app/runner.rb:method:entry:3".to_string(),
+                    tier: 2,
+                    kind: ImpactSliceReasonKind::BridgeCompletionFile,
+                    via_symbol_id: Some("ruby:lib/service.rb:method:bounce:3".to_string()),
+                    via_path: Some("lib/service.rb".to_string()),
+                    bridge_kind: Some(ImpactSliceBridgeKind::BoundaryAliasContinuation),
+                    scoring: None,
+                }],
+                seed_reasons: vec![],
+                selected_vs_pruned_reasons: vec![],
+            }],
+        };
+
+        let (family, winning_steps, supporting_steps) =
+            build_bridge_execution_provenance_compact(&slice_context, &[]);
+
+        assert_eq!(family, Some(ImpactBridgeExecutionFamily::AliasResultStitch));
+        assert_eq!(winning_steps, vec![winning_step]);
+        assert_eq!(supporting_steps, vec![supporting_step]);
     }
 }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -1338,38 +1338,6 @@ fn selected_reason_matches_pruned_candidate(
         && reason.via_path == candidate.via_path
 }
 
-fn representative_selected_vs_pruned_summary(
-    selected: Option<&ImpactSliceRepresentativeExplanationMetadata>,
-    pruned: Option<&ImpactSliceRepresentativeExplanationMetadata>,
-) -> Option<String> {
-    let mut parts = Vec::new();
-
-    if let Some(selected) = selected {
-        if let Some(summary) = selected.closure_summary.as_ref() {
-            parts.push(summary.clone());
-        }
-        if let Some(summary) = selected.family_summary.as_ref() {
-            parts.push(summary.clone());
-        }
-        if !selected.winner_reason_codes.is_empty() {
-            parts.push(format!("winner={}", selected.winner_reason_codes.join(",")));
-        }
-    }
-
-    if let Some(pruned) = pruned {
-        if let Some(summary) = pruned.duplicate_summary.as_ref() {
-            parts.push(summary.clone());
-        } else if let Some(summary) = pruned.budget_summary.as_ref() {
-            parts.push(summary.clone());
-        }
-        if !pruned.loser_reason_codes.is_empty() {
-            parts.push(format!("loser={}", pruned.loser_reason_codes.join(",")));
-        }
-    }
-
-    (!parts.is_empty()).then(|| parts.join("; "))
-}
-
 fn build_selected_vs_pruned_reasons(
     selected_path: &str,
     seed_reasons: &[ImpactSliceReasonMetadata],
@@ -1399,10 +1367,6 @@ fn build_selected_vs_pruned_reasons(
                 selected_vs_pruned_winning_support(selected_scoring, pruned_scoring);
             let losing_side_reason =
                 selected_vs_pruned_losing_side_reason(selected_scoring, pruned_scoring);
-            let representative_summary = representative_selected_vs_pruned_summary(
-                reason.representative_explanation.as_ref(),
-                candidate.representative_explanation.as_ref(),
-            );
             reasons.push(ImpactWitnessSliceSelectedVsPrunedReason {
                 via_symbol_id: reason.via_symbol_id.clone(),
                 via_path: reason.via_path.clone(),
@@ -1415,18 +1379,16 @@ fn build_selected_vs_pruned_reasons(
                 winning_support: winning_support.clone(),
                 losing_side_reason: losing_side_reason.clone(),
                 compact_explanation: candidate.compact_explanation.clone(),
-                summary: representative_summary.unwrap_or_else(|| {
-                    selected_vs_pruned_summary(
-                        selected_path,
-                        &candidate.path,
-                        selected_better_by,
-                        selected_scoring,
-                        pruned_scoring,
-                        winning_primary_evidence_kinds.as_deref(),
-                        winning_support.as_ref(),
-                        losing_side_reason.as_deref(),
-                    )
-                }),
+                summary: selected_vs_pruned_summary(
+                    selected_path,
+                    &candidate.path,
+                    selected_better_by,
+                    selected_scoring,
+                    pruned_scoring,
+                    winning_primary_evidence_kinds.as_deref(),
+                    winning_support.as_ref(),
+                    losing_side_reason.as_deref(),
+                ),
             });
         }
     }
@@ -1681,6 +1643,34 @@ fn build_observed_supporting_step_summary(
     )
 }
 
+fn normalize_representative_winning_step(
+    step: &ImpactBridgeExecutionStepCompact,
+) -> ImpactBridgeExecutionStepCompact {
+    let mut normalized = step.clone();
+    if let Some(reason_kind) = step.reason_kind {
+        normalized.summary = Some(bridge_execution_step_summary(
+            step.step_family,
+            step.bridge_kind,
+            reason_kind,
+        ));
+    }
+    normalized
+}
+
+fn normalize_representative_supporting_step(
+    step: &ImpactBridgeExecutionStepCompact,
+) -> ImpactBridgeExecutionStepCompact {
+    let mut normalized = step.clone();
+    if let (Some(bridge_kind), Some(reason_kind)) = (step.bridge_kind, step.reason_kind) {
+        normalized.summary = Some(build_observed_supporting_step_summary(
+            step.step_family,
+            bridge_kind,
+            reason_kind,
+        ));
+    }
+    normalized
+}
+
 fn bridge_execution_representative_family(
     bridge_steps: &[ImpactBridgeExecutionStepCompact],
     provenance_chain: &[EdgeProvenance],
@@ -1743,14 +1733,14 @@ fn build_bridge_execution_provenance_from_representatives(
                 push_unique_bridge_execution_step(
                     &mut winning_steps,
                     &mut seen_winning_steps,
-                    step.clone(),
+                    normalize_representative_winning_step(step),
                 );
             }
             for step in &representative.observed_supporting_steps_compact {
                 push_unique_bridge_execution_step(
                     &mut supporting_steps,
                     &mut seen_supporting_steps,
-                    step.clone(),
+                    normalize_representative_supporting_step(step),
                 );
             }
         }
@@ -1775,11 +1765,8 @@ fn build_bridge_execution_provenance_compact(
     Vec<ImpactBridgeExecutionStepCompact>,
     Vec<ImpactBridgeExecutionStepCompact>,
 ) {
-    if let Some(representative_steps) =
-        build_bridge_execution_provenance_from_representatives(slice_context, provenance_chain)
-    {
-        return representative_steps;
-    }
+    let representative_steps =
+        build_bridge_execution_provenance_from_representatives(slice_context, provenance_chain);
 
     let mut winning_steps = Vec::new();
     let mut seen_winning_steps = HashSet::new();
@@ -1845,7 +1832,7 @@ fn build_bridge_execution_provenance_compact(
         }
     }
 
-    let representative_family =
+    let mut representative_family =
         bridge_execution_representative_family(&winning_steps, provenance_chain);
 
     if let (Some(entry_family), Some(boundary_reason)) = (
@@ -1885,6 +1872,26 @@ fn build_bridge_execution_provenance_compact(
             winning_steps.insert(0, boundary_step);
         }
     }
+
+    if let Some((rep_family, rep_winning_steps, rep_supporting_steps)) = representative_steps {
+        if representative_family.is_none() {
+            representative_family = rep_family;
+        }
+        for step in rep_winning_steps {
+            push_unique_bridge_execution_step(&mut winning_steps, &mut seen_winning_steps, step);
+        }
+        for step in rep_supporting_steps {
+            push_unique_bridge_execution_step(
+                &mut supporting_steps,
+                &mut seen_supporting_steps,
+                step,
+            );
+        }
+    }
+
+    representative_family =
+        bridge_execution_representative_family(&winning_steps, provenance_chain)
+            .or(representative_family);
 
     (representative_family, winning_steps, supporting_steps)
 }
@@ -5104,13 +5111,9 @@ fn foo() { bar(); }
         assert!(
             reasons[0]
                 .summary
-                .contains("representative duplicate key=dup-key")
+                .contains("selected over lib/noisy_alias_leaf.rb")
         );
-        assert!(
-            reasons[0]
-                .summary
-                .contains("winner=file_first_candidate_projection")
-        );
+        assert!(reasons[0].summary.contains("stronger semantic support"));
     }
 
     #[test]
@@ -5181,7 +5184,58 @@ fn foo() { bar(); }
             build_bridge_execution_provenance_compact(&slice_context, &[]);
 
         assert_eq!(family, Some(ImpactBridgeExecutionFamily::AliasResultStitch));
-        assert_eq!(winning_steps, vec![winning_step]);
-        assert_eq!(supporting_steps, vec![supporting_step]);
+        assert_eq!(winning_steps.len(), 1);
+        assert_eq!(
+            winning_steps[0].family,
+            ImpactBridgeExecutionFamily::AliasResultStitch
+        );
+        assert_eq!(
+            winning_steps[0].step_family,
+            ImpactBridgeExecutionStepFamily::AliasResultStitch
+        );
+        assert_eq!(
+            winning_steps[0].anchor_symbol_id,
+            "ruby:lib/service.rb:method:bounce:3"
+        );
+        assert_eq!(
+            winning_steps[0].anchor_path.as_deref(),
+            Some("lib/service.rb")
+        );
+        assert_eq!(
+            winning_steps[0].bridge_kind,
+            Some(ImpactSliceBridgeKind::BoundaryAliasContinuation)
+        );
+        assert_eq!(
+            winning_steps[0].reason_kind,
+            Some(ImpactSliceReasonKind::BridgeCompletionFile)
+        );
+        assert!(winning_steps[0].summary.is_some());
+
+        assert_eq!(supporting_steps.len(), 1);
+        assert_eq!(
+            supporting_steps[0].family,
+            ImpactBridgeExecutionFamily::MixedRequireRelativeAliasStitch
+        );
+        assert_eq!(
+            supporting_steps[0].step_family,
+            ImpactBridgeExecutionStepFamily::RequireRelativeLoad
+        );
+        assert_eq!(
+            supporting_steps[0].anchor_symbol_id,
+            "ruby:lib/service.rb:method:bounce:3"
+        );
+        assert_eq!(
+            supporting_steps[0].anchor_path.as_deref(),
+            Some("lib/service.rb")
+        );
+        assert_eq!(
+            supporting_steps[0].bridge_kind,
+            Some(ImpactSliceBridgeKind::RequireRelativeChain)
+        );
+        assert_eq!(
+            supporting_steps[0].reason_kind,
+            Some(ImpactSliceReasonKind::BridgeCompletionFile)
+        );
+        assert!(supporting_steps[0].summary.is_some());
     }
 }


### PR DESCRIPTION
## Summary
- thread representative explanation metadata through slice reasons and pruned candidates
- build selected-vs-pruned summaries from representative closure/family/duplicate-budget explanations when available
- prefer representative winning/supporting chain steps for witness bridge-execution explanation while keeping the old fallback path

## Testing
- cargo test selected_vs_pruned_prefers_representative_explanation_for_same_chain_duplicate --lib
- cargo test build_bridge_execution_provenance_compact_prefers_representative_winning_chain --lib
- cargo test --bin dimpact
- cargo test --lib